### PR TITLE
fix: App Project Module ssRoot 의존성 추가

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -10,6 +10,7 @@ let project = Project.makeModule(
     dependencies: [
       .share(.designsystem),
       .share(.sSAlert),
+      .core(.sSRoot),
       .core(.coreLayers),
     ],
     testDependencies: [],

--- a/Projects/App/Sources/ContentView.swift
+++ b/Projects/App/Sources/ContentView.swift
@@ -11,11 +11,83 @@ import SwiftUI
 // MARK: - ContentView
 
 public struct ContentView: View {
+  @State var sectionTab: SSTabType = .envelope
+  
   public init() {}
 
   public var body: some View {
-    RootView(store: Store(initialState: RootViewFeature.State()) {
-      RootViewFeature()
-    })
+    
+    TabView(selection: $sectionTab) {
+      Group {
+        EnvelopeRootView()
+          .tag(SSTabType.envelope)
+        
+        InventoryRootView()
+          .tag(SSTabType.inventory)
+        
+        StatisticsRootView()
+          .tag(SSTabType.statistics)
+        
+        VoteRootView()
+          .tag(SSTabType.vote)
+        
+        MyPageRootView()
+          .tag(SSTabType.mypage)
+      }
+    }.toolbar(.hidden, for: .tabBar)
+    
+    VStack {
+        SSTabbar(selectionType: $sectionTab)
+    }.frame(height: 56)
+  }
+}
+
+//MARK: 보내요 RootView
+public struct EnvelopeRootView: View {
+  public var body: some View {
+    NavigationStack {
+      Color(.systemBackground)
+        .ignoresSafeArea()
+    }
+  }
+}
+
+//MARK: 받아요 RootView
+public struct InventoryRootView: View {
+  public var body: some View {
+    NavigationStack {
+      Color(.blue)
+        .edgesIgnoringSafeArea(.all)
+    }
+  }
+}
+
+//MARK: 통계 RootView
+public struct StatisticsRootView: View {
+  public var body: some View {
+    NavigationStack {
+      Color(.red)
+        .edgesIgnoringSafeArea(.all)
+    }
+  }
+}
+
+//MARK: 투표 RootView
+public struct VoteRootView: View {
+  public var body: some View {
+    NavigationStack {
+      Color(.green)
+        .edgesIgnoringSafeArea(.all)
+    }
+  }
+}
+
+//MARK: 마이페이지 RootView
+public struct MyPageRootView: View {
+  public var body: some View {
+    NavigationStack {
+      Color(.blue)
+        .edgesIgnoringSafeArea(.all)
+    }
   }
 }

--- a/Projects/Share/Designsystem/Sources/SSFont.swift
+++ b/Projects/Share/Designsystem/Sources/SSFont.swift
@@ -191,27 +191,6 @@ enum SizeTypes {
       6
     }
   }
-
-  var lineHeight: CGFloat {
-    return switch self {
-    case .l,
-         .xl,
-         .xxl,
-         .xxxl,
-         .xxxxl:
-      16
-    case .m,
-         .s,
-         .xs:
-      12
-    case .xxs:
-      10
-    case .xxxs:
-      8
-    case .xxxxs:
-      6
-    }
-  }
 }
 
 // MARK: - WeightType

--- a/Projects/Share/Designsystem/Sources/SSTabbar.swift
+++ b/Projects/Share/Designsystem/Sources/SSTabbar.swift
@@ -9,12 +9,57 @@
 import SwiftUI
 
 // MARK: SSTabbarType
-public enum SSTabType: String {
+public enum SSTabType: String, CaseIterable {
   case envelope
   case inventory
   case statistics
   case vote
   case mypage
+  
+  var title: String {
+    switch self {
+    case .envelope:
+      return "보내요"
+    case .inventory:
+      return "받아요"
+    case .statistics:
+      return "통계"
+    case .vote:
+      return "투표"
+    case .mypage:
+      return "마이페이지"
+    }
+  }
+  
+  var outlineImage: UIImage {
+    switch self {
+    case .envelope:
+      return SSImage.envelopeOutline
+    case .inventory:
+      return SSImage.inventoryOutline
+    case .statistics:
+      return SSImage.statisticsOutline
+    case .vote:
+      return SSImage.voteOutline
+    case .mypage:
+      return SSImage.mypageOutline
+    }
+  }
+  
+  var fillImage: UIImage {
+    switch self {
+    case .envelope:
+      return SSImage.envelopeFill
+    case .inventory:
+      return SSImage.inventoryFill
+    case .statistics:
+      return SSImage.statisticsFill
+    case .vote:
+      return SSImage.voteFill
+    case .mypage:
+      return SSImage.mypageFill
+    }
+  }
 }
 
 
@@ -28,79 +73,21 @@ public struct SSTabbar: View {
   
   public var body: some View {
     HStack(alignment: .center) {
-      Button {
-        selectionType = .envelope
-      } label: {
+        ForEach(SSTabType.allCases, id: \.self) {  tabbarType in
+          Button {
+            selectionType = tabbarType
+          } label: {
         GeometryReader { geometry in
-          VStack(alignment: .center, spacing: 4) {
-            Image(uiImage: selectionType == .envelope ? SSImage.envelopeFill : SSImage.envelopeOutline)
-              .resizable()
-              .frame(width: 24, height: 24, alignment: .center)
-            
-            SSText(text: "보내요", designSystemFont: .title_xxxxs)
-              .bold(true)
-              .foregroundColor(selectionType == .envelope ? SSColor.gray100 : SSColor.gray40)
-          }.frame(width: geometry.size.width, height: geometry.size.height)
-        }
-      }
-      Button {
-        selectionType = .inventory
-      } label: {
-        GeometryReader { geometry in
-          VStack(alignment: .center, spacing: 4) {
-            Image(uiImage: selectionType == .inventory ? SSImage.inventoryFill : SSImage.inventoryOutline)
-              .resizable()
-              .frame(width: 24, height: 24, alignment: .center)
-            SSText(text: "받아요", designSystemFont: .title_xxxxs)
-              .bold(true)
-              .foregroundColor(selectionType == .inventory ? SSColor.gray100 : SSColor.gray40)
-          }.frame(width: geometry.size.width, height: geometry.size.height)
-        }
-        
-      }
-      Button {
-        selectionType = .statistics
-      } label: {
-        GeometryReader { geometry in
-          VStack(alignment: .center, spacing: 4) {
-            Image(uiImage: selectionType == .statistics ? SSImage.statisticsFill : SSImage.statisticsOutline)
-              .resizable()
-              .frame(width: 24, height: 24, alignment: .center)
-            
-            SSText(text: "통계", designSystemFont: .title_xxxxs)
-              .bold(true)
-              .foregroundColor(selectionType == .statistics ? SSColor.gray100 : SSColor.gray40)
-          }.frame(width: geometry.size.width, height: geometry.size.height)
-        }
-      }
-      Button {
-        selectionType = .vote
-      } label: {
-        GeometryReader { geometry in
-          VStack(alignment: .center, spacing: 4) {
-            Image(uiImage: selectionType == .vote ? SSImage.voteFill : SSImage.voteOutline)
-              .resizable()
-              .frame(width: 24, height: 24, alignment: .center)
-            
-            SSText(text: "투표", designSystemFont: .title_xxxxs)
-              .bold(true)
-              .foregroundColor(selectionType == .vote ? SSColor.gray100 : SSColor.gray40)
-          }.frame(width: geometry.size.width, height: geometry.size.height)
-        }
-      }
-      Button {
-        selectionType = .mypage
-      } label: {
-        GeometryReader { geometry in
-          VStack(alignment: .center, spacing: 4) {
-            Image(uiImage: selectionType == .mypage ? SSImage.mypageFill : SSImage.mypageOutline)
-              .resizable()
-              .frame(width: 24, height: 24, alignment: .center)
-            
-            SSText(text: "마이페이지", designSystemFont: .title_xxxxs)
-              .bold(true)
-              .foregroundColor(selectionType == .mypage ? SSColor.gray100 : SSColor.gray40)
-          }.frame(width: geometry.size.width, height: geometry.size.height)
+            VStack(alignment: .center, spacing: 4) {
+              Image(uiImage: selectionType == tabbarType ? tabbarType.fillImage : tabbarType.outlineImage)
+                .resizable()
+                .frame(width: 24, height: 24, alignment: .center)
+              
+              SSText(text: tabbarType.title, designSystemFont: .title_xxxxs)
+                .bold(true)
+                .foregroundColor(selectionType == tabbarType ? SSColor.gray100 : SSColor.gray40)
+            }.frame(width: geometry.size.width, height: geometry.size.height)
+          }
         }
       }
     }

--- a/Projects/Share/Designsystem/Sources/SSTabbar.swift
+++ b/Projects/Share/Designsystem/Sources/SSTabbar.swift
@@ -1,0 +1,108 @@
+//
+//  SSTabbar.swift
+//  Designsystem
+//
+//  Created by Kim dohyun on 4/18/24.
+//  Copyright © 2024 com.susu. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: SSTabbarType
+public enum SSTabType: String {
+  case envelope
+  case inventory
+  case statistics
+  case vote
+  case mypage
+}
+
+
+//MARK: SSTabbar
+public struct SSTabbar: View {
+  @Binding private var selectionType: SSTabType
+
+  public init(selectionType: Binding<SSTabType>) {
+    self._selectionType = selectionType
+  }
+  
+  public var body: some View {
+    HStack(alignment: .center) {
+      Button {
+        selectionType = .envelope
+      } label: {
+        GeometryReader { geometry in
+          VStack(alignment: .center, spacing: 4) {
+            Image(uiImage: selectionType == .envelope ? SSImage.envelopeFill : SSImage.envelopeOutline)
+              .resizable()
+              .frame(width: 24, height: 24, alignment: .center)
+            
+            SSText(text: "보내요", designSystemFont: .title_xxxxs)
+              .bold(true)
+              .foregroundColor(selectionType == .envelope ? SSColor.gray100 : SSColor.gray40)
+          }.frame(width: geometry.size.width, height: geometry.size.height)
+        }
+      }
+      Button {
+        selectionType = .inventory
+      } label: {
+        GeometryReader { geometry in
+          VStack(alignment: .center, spacing: 4) {
+            Image(uiImage: selectionType == .inventory ? SSImage.inventoryFill : SSImage.inventoryOutline)
+              .resizable()
+              .frame(width: 24, height: 24, alignment: .center)
+            SSText(text: "받아요", designSystemFont: .title_xxxxs)
+              .bold(true)
+              .foregroundColor(selectionType == .inventory ? SSColor.gray100 : SSColor.gray40)
+          }.frame(width: geometry.size.width, height: geometry.size.height)
+        }
+        
+      }
+      Button {
+        selectionType = .statistics
+      } label: {
+        GeometryReader { geometry in
+          VStack(alignment: .center, spacing: 4) {
+            Image(uiImage: selectionType == .statistics ? SSImage.statisticsFill : SSImage.statisticsOutline)
+              .resizable()
+              .frame(width: 24, height: 24, alignment: .center)
+            
+            SSText(text: "통계", designSystemFont: .title_xxxxs)
+              .bold(true)
+              .foregroundColor(selectionType == .statistics ? SSColor.gray100 : SSColor.gray40)
+          }.frame(width: geometry.size.width, height: geometry.size.height)
+        }
+      }
+      Button {
+        selectionType = .vote
+      } label: {
+        GeometryReader { geometry in
+          VStack(alignment: .center, spacing: 4) {
+            Image(uiImage: selectionType == .vote ? SSImage.voteFill : SSImage.voteOutline)
+              .resizable()
+              .frame(width: 24, height: 24, alignment: .center)
+            
+            SSText(text: "투표", designSystemFont: .title_xxxxs)
+              .bold(true)
+              .foregroundColor(selectionType == .vote ? SSColor.gray100 : SSColor.gray40)
+          }.frame(width: geometry.size.width, height: geometry.size.height)
+        }
+      }
+      Button {
+        selectionType = .mypage
+      } label: {
+        GeometryReader { geometry in
+          VStack(alignment: .center, spacing: 4) {
+            Image(uiImage: selectionType == .mypage ? SSImage.mypageFill : SSImage.mypageOutline)
+              .resizable()
+              .frame(width: 24, height: 24, alignment: .center)
+            
+            SSText(text: "마이페이지", designSystemFont: .title_xxxxs)
+              .bold(true)
+              .foregroundColor(selectionType == .mypage ? SSColor.gray100 : SSColor.gray40)
+          }.frame(width: geometry.size.width, height: geometry.size.height)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 작업 내용
- [ ]  SSTabbar, SSTabbarType 추가
- [ ]  ContentView, 보내요, 받아요, 통계, 투표, 마이페이지 RootView 추가
- [ ] Merge conflict 으로 인한 중복 코드 제거
- [ ] App Module ssRoot Module 추가

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)


|View|View|
|:-:|:-:|
|   ![IMG_7182](https://github.com/ok-su-su/iOS/assets/23008224/8b4a867b-9a93-4abf-b9b5-4c2e71ca1a96)  |  ![IMG_7183](https://github.com/ok-su-su/iOS/assets/23008224/19ff19a0-abe5-4e66-b91a-a963c0447baa) |


<br/><br/><br/>


## 고민점 및 해결 방법
- Xcode Build시 SSRoot 모듈이 App 모듈에 의존성이 존재하지 않아 App 모듈에 의존성을 추가하였습니다 :) 혹시나 의존성이 다른 부분에 추가 해야한다면 말씀해주면 감사하겠습니다.
- 어느 부분에서 명확하게 Merge conflict이 난지 파악은 못하였으나 중복 코드가 있어 코드 제거 하였습니다.
- SwiftUI에서 제공하는 `TabView`에서는 Custom(Custom Font 적용이 안됨) 에 제한 적인 부분이 많아 `HStack`, `VStack` 등을 사용하여 구현 하였습니다 (탭바는 Hidden 처리) 
- 혹여나 기본 `TabView`에 Font 적용하는 것이 있으면 공유해주시면 감사하겠습니다.


<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)
- RootView를 모두 세팅 하였지만 폴더 구조를 어떻게 할지 고민중이라 임의적으로 ContentView 하단에 구현하였습니다. 나중에 폴더 구조에 대해 논의 하면 좋을 것 같습니다 :)








<br/><br/><br/>
close: #24 
