### PR TITLE
[Feature] FilterView 구현 

### DIFF
--- a/Projects/Feature/Sent/Project.swift
+++ b/Projects/Feature/Sent/Project.swift
@@ -9,6 +9,7 @@ let project = Project.makeModule(
     testingOptions: [.unitTest],
     dependencies: [
       .core(.coreLayers),
+      .share(.designsystem),
     ],
     testDependencies: []
   )

--- a/Projects/Feature/Sent/Sources/CustomTextField/CustomTextField.swift
+++ b/Projects/Feature/Sent/Sources/CustomTextField/CustomTextField.swift
@@ -1,0 +1,40 @@
+//
+//  CustomTextField.swift
+//  Sent
+//
+//  Created by MaraMincho on 5/1/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct CustomTextField {
+  @ObservableState
+  struct State {
+    var isOnAppear = false
+    var text: String = ""
+  }
+
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
+    case onAppear(Bool)
+    case closeButtonTapped
+  }
+
+  var body: some Reducer<State, Action> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case let .onAppear(isAppear):
+        state.isOnAppear = isAppear
+        return .none
+      case .closeButtonTapped:
+        state.text = ""
+        return .none
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Feature/Sent/Sources/CustomTextField/CustomTextFieldView.swift
+++ b/Projects/Feature/Sent/Sources/CustomTextField/CustomTextFieldView.swift
@@ -1,0 +1,68 @@
+//
+//  CustomTextFieldView.swift
+//  Sent
+//
+//  Created by MaraMincho on 5/1/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Designsystem
+import SwiftUI
+
+struct CustomTextFieldView: View {
+  // MARK: Reducer
+
+  @Bindable
+  var store: StoreOf<CustomTextField>
+
+  // MARK: Content
+
+  @ViewBuilder
+  private func makeContentView() -> some View {
+    HStack(alignment: .center, spacing: 0) {
+      SSImage
+        .commonSearch
+
+      Spacer()
+        .frame(width: 8)
+
+      TextField("", text: $store.text, prompt: Constants.prompt)
+        .modifier(SSTypoModifier(.text_xxs))
+        .frame(maxWidth: .infinity)
+        .foregroundStyle(SSColor.gray100)
+
+      Spacer()
+        .frame(width: 8)
+
+      if store.state.text != "" {
+        SSImage
+          .commonClose
+          .onTapGesture {
+            store.send(.closeButtonTapped)
+          }
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 8)
+  }
+
+  var body: some View {
+    ZStack {
+      SSColor
+        .gray20
+        .ignoresSafeArea()
+      makeContentView()
+    }
+    .frame(maxWidth: .infinity, maxHeight: 44)
+    .clipShape(RoundedRectangle(cornerRadius: 4))
+    .onAppear {
+      store.send(.onAppear(true))
+    }
+  }
+
+  private enum Metrics {}
+
+  private enum Constants {
+    static let prompt = Text("찾고 싶은 봉투를 검색해보세요")
+  }
+}

--- a/Projects/Feature/Sent/Sources/FilterDialView/FilterDial.swift
+++ b/Projects/Feature/Sent/Sources/FilterDialView/FilterDial.swift
@@ -13,6 +13,11 @@ struct FilterDial {
   @ObservableState
   struct State {
     var isOnAppear = false
+    var filterDialProperty: FilterDialProperty
+
+    init(filterDialProperty: FilterDialProperty) {
+      self.filterDialProperty = filterDialProperty
+    }
   }
 
   enum Action: Equatable {

--- a/Projects/Feature/Sent/Sources/FilterDialView/FilterDial.swift
+++ b/Projects/Feature/Sent/Sources/FilterDialView/FilterDial.swift
@@ -22,6 +22,7 @@ struct FilterDial {
 
   enum Action: Equatable {
     case onAppear(Bool)
+    case tappedDial(FilterDialType)
   }
 
   var body: some Reducer<State, Action> {
@@ -30,7 +31,9 @@ struct FilterDial {
       case let .onAppear(isAppear):
         state.isOnAppear = isAppear
         return .none
-      default:
+
+      case let .tappedDial(type):
+        state.filterDialProperty.currentType = type
         return .none
       }
     }

--- a/Projects/Feature/Sent/Sources/FilterDialView/FilterDialProperty.swift
+++ b/Projects/Feature/Sent/Sources/FilterDialView/FilterDialProperty.swift
@@ -1,0 +1,20 @@
+//
+//  FilterDialProperty.swift
+//  Sent
+//
+//  Created by MaraMincho on 5/1/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Foundation
+
+struct FilterDialProperty: Equatable {
+  var currentType: FilterType = .newest
+
+  enum FilterType: Equatable, CaseIterable {
+    case newest
+    case oldest
+    case maximumPrice
+    case minimumPrice
+  }
+}

--- a/Projects/Feature/Sent/Sources/FilterDialView/FilterDialProperty.swift
+++ b/Projects/Feature/Sent/Sources/FilterDialView/FilterDialProperty.swift
@@ -6,15 +6,34 @@
 //  Copyright © 2024 com.oksusu. All rights reserved.
 //
 
+import Designsystem
 import Foundation
 
-struct FilterDialProperty: Equatable {
-  var currentType: FilterType = .newest
+// MARK: - FilterDialProperty
 
-  enum FilterType: Equatable, CaseIterable {
-    case newest
-    case oldest
-    case maximumPrice
-    case minimumPrice
+struct FilterDialProperty: Equatable {
+  var currentType: FilterDialType = .newest
+  var types = FilterDialType.allCases
+}
+
+// MARK: - FilterDialType
+
+enum FilterDialType: Equatable, CaseIterable {
+  case newest
+  case oldest
+  case maximumPrice
+  case minimumPrice
+
+  var name: String {
+    switch self {
+    case .maximumPrice:
+      "금액 높은 순"
+    case .minimumPrice:
+      "금액 낮은 순"
+    case .newest:
+      "최신 순"
+    case .oldest:
+      "오래된 순"
+    }
   }
 }

--- a/Projects/Feature/Sent/Sources/FilterDialView/FilterDialView.swift
+++ b/Projects/Feature/Sent/Sources/FilterDialView/FilterDialView.swift
@@ -18,14 +18,32 @@ struct FilterDialView: View {
   // MARK: Content
 
   @ViewBuilder
-  private func makeContentView() -> some View {}
+  private func makeContentView() -> some View {
+    ForEach(0 ..< store.filterDialProperty.types.count) { ind in
+      let curSelected = store.filterDialProperty.currentType
+      let cur = store.filterDialProperty.types[ind]
+      SSButton(
+        .init(
+          size: .sh48,
+          status: cur == curSelected ? .active : .inactive,
+          style: .ghost,
+          color: .black,
+          buttonText: cur.name,
+          frame: .init(maxWidth: .infinity)
+        )) {
+          store.send(.tappedDial(cur))
+        }
+    }
+  }
 
   var body: some View {
     ZStack {
       SSColor
-        .gray15
+        .gray10
         .ignoresSafeArea()
       VStack {
+        Spacer()
+          .frame(height: 16)
         makeContentView()
       }
     }

--- a/Projects/Feature/Sent/Sources/Protocols/FeatureAction.swift
+++ b/Projects/Feature/Sent/Sources/Protocols/FeatureAction.swift
@@ -15,18 +15,18 @@ public protocol FeatureAction {
   associatedtype ScopeAction
   associatedtype DelegateAction
 
-  // NOTE: view 에서 사용되는 Action 을 정의합니다.
+  /// NOTE: view 에서 사용되는 Action 을 정의합니다.
   static func view(_: ViewAction) -> Self
 
-  // NOTE: 그 외 Reducer 내부적으로 사용되는 Action 을 정의합니다.
+  /// NOTE: 그 외 Reducer 내부적으로 사용되는 Action 을 정의합니다.
   static func inner(_: InnerAction) -> Self
 
-  // NOTE: 비동기적으로 돌아가는 Action 을 정의합니다.
+  /// NOTE: 비동기적으로 돌아가는 Action 을 정의합니다.
   static func async(_: AsyncAction) -> Self
 
-  // NOTE: 자식 Redcuer 에서 사용되는 Action 을 정의합니다.
+  /// NOTE: 자식 Redcuer 에서 사용되는 Action 을 정의합니다.
   static func scope(_: ScopeAction) -> Self
 
-  // NOTE: 부모 Reducer 에서 사용되는 Action 을 정의합니다.
+  /// NOTE: 부모 Reducer 에서 사용되는 Action 을 정의합니다.
   static func delegate(_: DelegateAction) -> Self
 }

--- a/Projects/Feature/Sent/Sources/Protocols/FeatureAction.swift
+++ b/Projects/Feature/Sent/Sources/Protocols/FeatureAction.swift
@@ -1,0 +1,32 @@
+//
+//  FeatureAction.swift
+//  Sent
+//
+//  Created by MaraMincho on 5/2/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeatureAction {
+  associatedtype ViewAction
+  associatedtype InnerAction
+  associatedtype AsyncAction
+  associatedtype ScopeAction
+  associatedtype DelegateAction
+
+  // NOTE: view 에서 사용되는 Action 을 정의합니다.
+  static func view(_: ViewAction) -> Self
+
+  // NOTE: 그 외 Reducer 내부적으로 사용되는 Action 을 정의합니다.
+  static func inner(_: InnerAction) -> Self
+
+  // NOTE: 비동기적으로 돌아가는 Action 을 정의합니다.
+  static func async(_: AsyncAction) -> Self
+
+  // NOTE: 자식 Redcuer 에서 사용되는 Action 을 정의합니다.
+  static func scope(_: ScopeAction) -> Self
+
+  // NOTE: 부모 Reducer 에서 사용되는 Action 을 정의합니다.
+  static func delegate(_: DelegateAction) -> Self
+}

--- a/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilter.swift
+++ b/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilter.swift
@@ -23,6 +23,7 @@ struct SentEnvelopeFilter {
     var sentPeopleAdaptor: SentPeopleAdaptor
     var header: HeaderViewFeature.State = .init(.init(title: "필터", type: .depth2Default))
     var sliderProperty: CustomSlider = .init(start: 0, end: 100_000, width: UIScreen.main.bounds.size.width - 42)
+    var customTextField = CustomTextField.State()
     init(sentPeople: [SentPerson]) {
       sentPeopleAdaptor = .init(sentPeople: sentPeople)
     }
@@ -43,6 +44,7 @@ struct SentEnvelopeFilter {
     case tappedSelectedPerson(UUID)
     case reset
     case delegate(Delegate)
+    case customTextField(CustomTextField.Action)
     enum Delegate: Equatable {
       case tappedApplyButton(SentPeopleAdaptor)
     }
@@ -54,7 +56,19 @@ struct SentEnvelopeFilter {
     Scope(state: \.header, action: \.header) {
       HeaderViewFeature()
     }
+
+    Scope(state: \.customTextField, action: \.customTextField) {
+      CustomTextField()
+    }
+    .onChange(of: \.customTextField.text) { _, newValue in
+      Reduce { state, _ in
+        state.textFieldText = newValue
+        return .none
+      }
+    }
+
     BindingReducer()
+
     Reduce { state, action in
       switch action {
       case let .tappedPerson(ind):

--- a/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilter.swift
+++ b/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilter.swift
@@ -19,7 +19,6 @@ struct SentEnvelopeFilter {
   struct State {
     var isOnAppear = false
     var textFieldText: String = ""
-    var isHighlight: Bool = true
     var sentPeopleAdaptor: SentPeopleAdaptor
     var header: HeaderViewFeature.State = .init(.init(title: "필터", type: .depth2Default))
     var sliderProperty: CustomSlider = .init(start: 0, end: 100_000, width: UIScreen.main.bounds.size.width - 42)
@@ -71,6 +70,10 @@ struct SentEnvelopeFilter {
 
     Reduce { state, action in
       switch action {
+      case .header(.tappedDismissButton):
+        return .run { send in
+          await send(.reset)
+        }
       case let .tappedPerson(ind):
         state.sentPeopleAdaptor.select(selectedId: ind)
         return .none

--- a/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilterView.swift
+++ b/Projects/Feature/Sent/Sources/SentEnvelopeFilter/SentEnvelopeFilterView.swift
@@ -165,7 +165,10 @@ struct SentEnvelopeFilterView: View {
     VStack(alignment: .leading, spacing: 0) {
       Text(Constants.searchTextFieldTitle)
         .modifier(SSTypoModifier(.title_xs))
-      SSTextField(isDisplay: false, text: $store.textFieldText, property: .account, isHighlight: $store.isHighlight)
+
+      CustomTextFieldView(store: store.scope(state: \.customTextField, action: \.customTextField))
+        .padding(.vertical, 16)
+
       Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 8) {
         makePersonButton()
       }

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMain.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMain.swift
@@ -37,25 +37,47 @@ struct SentMain {
     }
   }
 
-  enum Action: Equatable {
-    case header(HeaderViewFeature.Action)
-    case tabBar(SSTabBarFeature.Action)
+  enum Action: Equatable, FeatureAction {
+    case view(ViewAction)
+    case inner(InnerAction)
+    case async(AsyncAction)
+    case scope(ScopeAction)
+    case delegate(DelegateAction)
+  }
+
+  @CasePathable
+  enum ViewAction: Equatable {
     case tappedFirstButton
     case filterButtonTapped
     case tappedEmptyEnvelopeButton
-    case envelopes(IdentifiedActionOf<Envelope>)
-    case filterDial(FilterDial.Action)
     case setFilterDialSheet(Bool)
   }
 
+  @CasePathable
+  enum InnerAction: Equatable {}
+
+  @CasePathable
+  enum AsyncAction: Equatable {}
+
+  @CasePathable
+  enum ScopeAction: Equatable {
+    case header(HeaderViewFeature.Action)
+    case tabBar(SSTabBarFeature.Action)
+    case filterDial(FilterDial.Action)
+
+    case envelopes(IdentifiedActionOf<Envelope>)
+  }
+
+  enum DelegateAction: Equatable {}
+
   var body: some Reducer<State, Action> {
-    Scope(state: \.header, action: \.header) {
+    Scope(state: \.header, action: \.scope.header) {
       HeaderViewFeature()
     }
-    Scope(state: \.tabBar, action: /Action.tabBar) {
+    Scope(state: \.tabBar, action: \.scope.tabBar) {
       SSTabBarFeature()
     }
-    Scope(state: \.filterDial, action: \.filterDial) {
+    Scope(state: \.filterDial, action: \.scope.filterDial) {
       FilterDial()
     }
     .onChange(of: \.filterDial.filterDialProperty) { _, newValue in
@@ -66,24 +88,19 @@ struct SentMain {
     }
     Reduce { state, action in
       switch action {
-      case .setFilterDialSheet(true):
+      case .view(.setFilterDialSheet(true)):
         state.isDialPresented = true
         return .none
 
-      case .setFilterDialSheet(false):
+      case .view(.setFilterDialSheet(false)):
         state.isDialPresented = false
         return .none
 
-      case .tappedFirstButton:
-        return .none
-
-      case .filterButtonTapped:
-        return .none
       default:
         return .none
       }
     }
-    .forEach(\.envelopes, action: \.envelopes) {
+    .forEach(\.envelopes, action: \.scope.envelopes) {
       Envelope()
     }
   }

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -58,7 +58,14 @@ struct SentMainView: View {
           .frame(height: 16)
         VStack {
           HStack(spacing: Constants.topButtonsSpacing) {
-            SSButton(Constants.latestButtonProperty) {
+            SSButton(.init(
+              size: .sh32,
+              status: .active,
+              style: .ghost,
+              color: .black,
+              leftIcon: .icon(SSImage.commonFilter),
+              buttonText: store.filterDialProperty.currentType.name
+            )) {
               store.send(.setFilterDialSheet(true))
             }
             ZStack {

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -100,7 +100,7 @@ struct SentMainView: View {
     }
     .sheet(isPresented: $store.isDialPresented.sending(\.setFilterDialSheet)) {
       showFilterDialView()
-        .presentationDetents([.height(200), .medium, .large])
+        .presentationDetents([.height(240), .medium, .large])
         .presentationDragIndicator(.automatic)
     }
   }

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -108,7 +108,7 @@ struct SentMainView: View {
     .sheet(isPresented: $store.isDialPresented.sending(\.setFilterDialSheet)) {
       showFilterDialView()
         .presentationDetents([.height(240), .medium, .large])
-        .presentationDragIndicator(.automatic) 
+        .presentationDragIndicator(.automatic)
     }
   }
 

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -108,7 +108,7 @@ struct SentMainView: View {
     .sheet(isPresented: $store.isDialPresented.sending(\.setFilterDialSheet)) {
       showFilterDialView()
         .presentationDetents([.height(240), .medium, .large])
-        .presentationDragIndicator(.automatic)
+        .presentationDragIndicator(.automatic) 
     }
   }
 

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -28,13 +28,13 @@ struct SentMainView: View {
           .modifier(SSTypoModifier(.text_s))
           .foregroundStyle(SSColor.gray50)
         SSButton(Constants.emptyEnvelopeButtonProperty) {
-          store.send(.tappedEmptyEnvelopeButton)
+          store.send(.view(.tappedEmptyEnvelopeButton))
         }
         Spacer()
       }
     } else {
       ScrollView {
-        ForEach(store.scope(state: \.envelopes, action: \.envelopes)) { store in
+        ForEach(store.scope(state: \.envelopes, action: \.scope.envelopes)) { store in
           EnvelopeView(store: store)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -44,7 +44,7 @@ struct SentMainView: View {
 
   @ViewBuilder
   func showFilterDialView() -> some View {
-    FilterDialView(store: store.scope(state: \.filterDial, action: \.filterDial))
+    FilterDialView(store: store.scope(state: \.filterDial, action: \.scope.filterDial))
   }
 
   var body: some View {
@@ -53,7 +53,7 @@ struct SentMainView: View {
         .gray15
         .ignoresSafeArea()
       VStack {
-        HeaderView(store: store.scope(state: \.header, action: \.header))
+        HeaderView(store: store.scope(state: \.header, action: \.scope.header))
         Spacer()
           .frame(height: 16)
         VStack {
@@ -66,7 +66,7 @@ struct SentMainView: View {
               leftIcon: .icon(SSImage.commonFilter),
               buttonText: store.filterDialProperty.currentType.name
             )) {
-              store.send(.setFilterDialSheet(true))
+              store.send(.view(.setFilterDialSheet(true)))
             }
             ZStack {
               // TODO: Navigation 변경
@@ -80,7 +80,7 @@ struct SentMainView: View {
                 .init(name: "사귀자"),
               ]))) {
                 SSButton(Constants.notSelectedFilterButtonProperty) {
-                  store.send(.filterButtonTapped)
+                  store.send(.view(.filterButtonTapped))
                 }
                 .allowsHitTesting(false)
               }
@@ -97,7 +97,7 @@ struct SentMainView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .padding(.horizontal, Constants.leadingAndTrailingSpacing)
     .safeAreaInset(edge: .bottom) {
-      SSTabbar(store: store.scope(state: \.tabBar, action: \.tabBar))
+      SSTabbar(store: store.scope(state: \.tabBar, action: \.scope.tabBar))
         .background {
           Color.white
         }
@@ -105,7 +105,7 @@ struct SentMainView: View {
         .frame(height: 56)
         .toolbar(.hidden, for: .tabBar)
     }
-    .sheet(isPresented: $store.isDialPresented.sending(\.setFilterDialSheet)) {
+    .sheet(isPresented: $store.isDialPresented.sending(\.view.setFilterDialSheet)) {
       showFilterDialView()
         .presentationDetents([.height(240), .medium, .large])
         .presentationDragIndicator(.automatic)

--- a/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
+++ b/Projects/Feature/Sent/Sources/SentMainView/SentMainView.swift
@@ -42,6 +42,11 @@ struct SentMainView: View {
     }
   }
 
+  @ViewBuilder
+  func showFilterDialView() -> some View {
+    FilterDialView(store: store.scope(state: \.filterDial, action: \.filterDial))
+  }
+
   var body: some View {
     ZStack {
       SSColor
@@ -54,7 +59,7 @@ struct SentMainView: View {
         VStack {
           HStack(spacing: Constants.topButtonsSpacing) {
             SSButton(Constants.latestButtonProperty) {
-              store.send(.tappedFirstButton)
+              store.send(.setFilterDialSheet(true))
             }
             ZStack {
               // TODO: Navigation 변경
@@ -92,6 +97,11 @@ struct SentMainView: View {
         .ignoresSafeArea()
         .frame(height: 56)
         .toolbar(.hidden, for: .tabBar)
+    }
+    .sheet(isPresented: $store.isDialPresented.sending(\.setFilterDialSheet)) {
+      showFilterDialView()
+        .presentationDetents([.height(200), .medium, .large])
+        .presentationDragIndicator(.automatic)
     }
   }
 

--- a/Projects/Share/Designsystem/Sources/SSButtonProperty.swift
+++ b/Projects/Share/Designsystem/Sources/SSButtonProperty.swift
@@ -17,7 +17,7 @@ public struct SSButtonProperty {
   let color: ButtonColor
   let leftIcon: LeftIcon
   let rightIcon: RightIcon
-  let buttonText: String
+  var buttonText: String
   let frame: SSButtonFrame
 
   public struct SSButtonFrame {
@@ -79,6 +79,10 @@ public struct SSButtonProperty {
 
   public func toggleProperty() -> Self {
     return .init(size: size, status: status == .active ? .inactive : .active, style: style, color: color, leftIcon: leftIcon, rightIcon: rightIcon, buttonText: buttonText, frame: frame)
+  }
+
+  public mutating func update(text: String) {
+    buttonText = text
   }
 }
 

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "115fe5af41d333b6156d4924d7c7058bc77fd580",
-        "version" : "1.9.2"
+        "revision" : "e6c0959044cbe2c934ac0ce9c3c4ead86350f44f",
+        "version" : "1.10.2"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "520c458a832d1287e6b698c5f657ae848fd696ff",
-        "version" : "1.1.4"
+        "revision" : "8e8ca36c02abc7775a3ab81f9468c0df5fe22c2c",
+        "version" : "1.1.7"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   name: "IOS",
   dependencies: [
     .package(url: "https://github.com/Moya/Moya.git", exact: "15.0.3"),
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.9.2")
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", exact: "1.10.2")
   ]
 )
 


### PR DESCRIPTION
## 작업 내용

- [ ] FilterView 구현
- [ ] 최신순에 나오는 half modal 구현
- [ ] Navigation 구현
- [ ] Navigation과 Shared State를 포함한 로직 구현 
- [ ] TabBa관련한 로직 구현 
- [ ] TCA Version 1.10.3 UPdate

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)
![Simulator Screen Recording - iPhone 15 Pro - 2024-05-01 at 15 51 26](https://github.com/ok-su-su/iOS/assets/103064352/fe2d3127-4a8d-4cbd-9586-1c3e98cf331e)



<br/><br/><br/>


## 고민점 및 해결 방법



### Navigation에 관해서

TCA특성상 NavigatinoView을 하려면 꼭 NavigationStcak이 필요합니다. 이렇게 된다면 우리가 생각하는 Coordinator을 구현하기 위해서 어떻게 해야할까 고민했습니다. 결론적으로 각자 Feature마다 NavigationView를 두어서 이동하자라는 결론에 도달했습니다. 각 탭바 탭 마다, NavigationView를 한개씩 두게 된다면 다른 Feature들은 다른 탭들의 Feature들은 현재Feature의 View에 대해서 무지합니다. (public이 아닌 internal로 선언되어 있어서)

이것을 구현하기 위해서 NotifiactionCenter를 활용했습니다. Notification을 발생시켜, TabbarEvent마다 화면전환할 수 있게 만들었습니다. 아마 공통적으로 사용되는 Notification에 대한 모듈들을 분리하는 편이 좋아보입니다. 현재는 DesignSystem에 위치시켰습니다. 

```swift
  public static let tappedInventory = Notification.Name("tappedInventory")

 case .inventory:
          NotificationCenter.default.post(name: SSNotificationName.tappedInventory, object: nil)



```


![image](https://github.com/ok-su-su/iOS/assets/103064352/1ad31876-f199-423d-b703-968270706ec7)


### Navigation과 정보 전달

필터 뷰로 넘어갈 때 Navigation에 관한 정보를 줘야 합니다. 그리고 필터가 완료되었을 때 Navigation이 pop되어야 하는데 pop될때는 정보를 넘기지 못합니다. 왜냐하면 tca특성상 새로운 store.state를 만들어서 넘기기 떄문입니다. 그래서 자료를 찾아봤는데도 해답을 찾지 못해서 MainView가 있는데도 그냥 pushMainView를 새로 만들어 Push 하는 방법으로 넘겼습니다. 이러면 화면 stack이 비어지지 않는 문제가 있는데, 해결 방법을 아직 강구하지 못했습니다. 이걸 외부 종속으로 (userDefault나 다른 방법으로 돌리는 것도 있지만, tca업데이트 이후 **shared State를 활용하려 합니다.**



<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)

뷰를 만들 떄 마다 Constants에서 값을 꺼내 쓰는 것이 좋아 보였는데 다시 생각하니까, 그냥 hard하게 굳이 큰 문제가 없을 것 같다는 생각이 들었습니다. 그래서 좀 하드코딩된 상수들을 남발했던 경향이 있는데 어떻게 생각하시는지 궁금합니다!


tabbar와 header에 자꾸 로직이 들어가는데 DesignSystem말고 corelayer에 따로 만들어도 좋을 것 같습니다!


<br/><br/><br/>
## 레퍼런스



<br/><br/><br/>
close: # 38
