### PR TITLE
[Feature] MyPage information EditView 구현 

### DIFF
--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2024 com.oksusu. All rights reserved.
 //
 import ComposableArchitecture
-import Foundation
 import Designsystem
+import Foundation
 
 @Reducer
 struct MyPageEdit {
@@ -15,7 +15,10 @@ struct MyPageEdit {
   struct State: Equatable {
     var isOnAppear = false
     var header: HeaderViewFeature.State = .init(.init(title: "내정보", type: .depth2Text("등록")))
-
+    var tabBar: SSTabBarFeature.State = .init(tabbarType: .mypage)
+    var helper: MyPageEditHelper = .init()
+    var presentYearModal: Bool = false
+    
     init() {}
   }
 
@@ -36,19 +39,40 @@ struct MyPageEdit {
   enum AsyncAction: Equatable {}
 
   @CasePathable
-  enum ScopeAction: Equatable {}
+  enum ScopeAction: Equatable {
+    case header(HeaderViewFeature.Action)
+    case tabBar(SSTabBarFeature.Action)
+  }
 
   enum DelegateAction: Equatable {}
 
   var body: some Reducer<State, Action> {
+    
+    Scope(state: \.header, action: \.scope.header) {
+      HeaderViewFeature()
+    }
+    
+    Scope(state: \.tabBar, action: \.scope.tabBar) {
+      SSTabBarFeature()
+    }
+    
     Reduce { state, action in
       switch action {
       case let .view(.onAppear(isAppear)):
         state.isOnAppear = isAppear
         return .none
-      default:
+      case .scope(.header(.tappedTextButton)):
+        // TODO: 저장버튼 눌렀을 때 어떤 변화가 생겨야할지
+        return .none
+      case .scope(.header):
+        return .none
+      case .scope(.tabBar):
         return .none
       }
     }
   }
+}
+
+extension Reducer where Self.State == MyPageEdit.State, Self.Action == MyPageEdit.Action {
+  
 }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -5,12 +5,16 @@
 //  Created by MaraMincho on 5/15/24.
 //  Copyright © 2024 com.oksusu. All rights reserved.
 //
+import Combine
 import ComposableArchitecture
 import Designsystem
 import Foundation
 
+// MARK: - MyPageEdit
+
 @Reducer
 struct MyPageEdit {
+  var routingPublisher: PassthroughSubject<Routing, Never> = .init()
   @ObservableState
   struct State: Equatable {
     var isOnAppear = false
@@ -18,7 +22,7 @@ struct MyPageEdit {
     var tabBar: SSTabBarFeature.State = .init(tabbarType: .mypage)
     var helper: MyPageEditHelper = .init()
     var presentYearModal: Bool = false
-    
+
     init() {}
   }
 
@@ -28,6 +32,7 @@ struct MyPageEdit {
     case async(AsyncAction)
     case scope(ScopeAction)
     case delegate(DelegateAction)
+    case route(Routing)
   }
 
   enum ViewAction: Equatable {
@@ -46,16 +51,19 @@ struct MyPageEdit {
 
   enum DelegateAction: Equatable {}
 
+  enum Routing: Equatable {
+    case dismiss
+  }
+
   var body: some Reducer<State, Action> {
-    
     Scope(state: \.header, action: \.scope.header) {
       HeaderViewFeature()
     }
-    
+
     Scope(state: \.tabBar, action: \.scope.tabBar) {
       SSTabBarFeature()
     }
-    
+
     Reduce { state, action in
       switch action {
       case let .view(.onAppear(isAppear)):
@@ -68,11 +76,12 @@ struct MyPageEdit {
         return .none
       case .scope(.tabBar):
         return .none
+      case let .route(destination):
+        routingPublisher.send(destination)
+        return .none
       }
     }
   }
 }
 
-extension Reducer where Self.State == MyPageEdit.State, Self.Action == MyPageEdit.Action {
-  
-}
+extension Reducer where Self.State == MyPageEdit.State, Self.Action == MyPageEdit.Action {}

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -35,8 +35,11 @@ struct MyPageEdit {
     case route(Routing)
   }
 
+  @CasePathable
   enum ViewAction: Equatable {
     case onAppear(Bool)
+    case selectGender(Gender)
+    case nameEdited(String)
   }
 
   enum InnerAction: Equatable {}
@@ -78,6 +81,13 @@ struct MyPageEdit {
         return .none
       case let .route(destination):
         routingPublisher.send(destination)
+        return .none
+      case let .view(.nameEdited(text)):
+        state.helper.editName(text: text)
+        return .none
+
+      case let .view(.selectGender(gender)):
+        state.helper.editedValue.gender = gender
         return .none
       }
     }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -20,10 +20,14 @@ struct MyPageEdit {
     var isOnAppear = false
     var header: HeaderViewFeature.State = .init(.init(title: "내정보", type: .depth2Text("등록")))
     var tabBar: SSTabBarFeature.State = .init(tabbarType: .mypage)
-    var helper: MyPageEditHelper = .init()
-    var presentYearModal: Bool = false
+    @Shared var helper: MyPageEditHelper
+    var selectYearIsPresented: Bool = false
+    var selectYear: SelectYearBottomSheet.State
 
-    init() {}
+    init() {
+      _helper = Shared(.init())
+      selectYear = .init(originalYear: nil, selectedYear: _helper.editedValue.birthDate)
+    }
   }
 
   enum Action: Equatable, FeatureAction {
@@ -40,6 +44,7 @@ struct MyPageEdit {
     case onAppear(Bool)
     case selectGender(Gender)
     case nameEdited(String)
+    case selectedYearItem(Bool)
   }
 
   enum InnerAction: Equatable {}
@@ -50,6 +55,7 @@ struct MyPageEdit {
   enum ScopeAction: Equatable {
     case header(HeaderViewFeature.Action)
     case tabBar(SSTabBarFeature.Action)
+    case selectYear(SelectYearBottomSheet.Action)
   }
 
   enum DelegateAction: Equatable {}
@@ -67,6 +73,9 @@ struct MyPageEdit {
       SSTabBarFeature()
     }
 
+    Scope(state: \.selectYear, action: \.scope.selectYear) {
+      SelectYearBottomSheet()
+    }
     Reduce { state, action in
       switch action {
       case let .view(.onAppear(isAppear)):
@@ -88,6 +97,14 @@ struct MyPageEdit {
 
       case let .view(.selectGender(gender)):
         state.helper.editedValue.gender = gender
+        return .none
+
+      case let .view(.selectedYearItem(present)):
+        state.selectYearIsPresented = present
+        return .none
+
+      case let .scope(.selectYear(.tappedYear(title))):
+        state.selectYearIsPresented = false
         return .none
       }
     }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -1,0 +1,52 @@
+//
+//  MyPageEdit.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct MyPageEdit {
+  @ObservableState
+  struct State: Equatable {
+    var isOnAppear = false
+
+    init() {}
+  }
+
+  enum Action: Equatable, FeatureAction {
+    case view(ViewAction)
+    case inner(InnerAction)
+    case async(AsyncAction)
+    case scope(ScopeAction)
+    case delegate(DelegateAction)
+  }
+
+  enum ViewAction: Equatable {
+    case onAppear(Bool)
+  }
+
+  enum InnerAction: Equatable {}
+
+  enum AsyncAction: Equatable {}
+
+  @CasePathable
+  enum ScopeAction: Equatable {}
+
+  enum DelegateAction: Equatable {}
+
+  var body: some Reducer<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case let .view(.onAppear(isAppear)):
+        state.isOnAppear = isAppear
+        return .none
+      default:
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -7,12 +7,14 @@
 //
 import ComposableArchitecture
 import Foundation
+import Designsystem
 
 @Reducer
 struct MyPageEdit {
   @ObservableState
   struct State: Equatable {
     var isOnAppear = false
+    var header: HeaderViewFeature.State = .init(.init(title: "내정보", type: .depth2Text("등록")))
 
     init() {}
   }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -24,10 +24,7 @@ struct MyPageEdit {
     var selectYearIsPresented: Bool = false
     var selectYear: SelectYearBottomSheet.State?
 
-    init() {
-      let initialHelpValue = MyPageEditHelper()
-      helper = initialHelpValue
-    }
+    init() {}
   }
 
   enum Action: Equatable, FeatureAction {

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
@@ -1,0 +1,49 @@
+//
+//  MyPageEditHelper.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Foundation
+
+struct MyPageEditHelper {
+  var originalValue: MyPageInformationProperty
+  var editedValue: MyPageInformationProperty
+}
+
+enum Gender: Int, Identifiable  {
+  case male = 0
+  case female
+  
+  var id: Int { return rawValue }
+}
+
+protocol MyPageInformationPropertiable {
+  
+  /// 내정보에 표시되는 이름입니다.
+  var name: String? { get set}
+  
+  /// 내정보에 표시되는 생일 입니다.
+  var birthDate: Date? {get set}
+  
+  /// 내정보에 표시되는 성별 입니다.
+  var gender: Gender? { get set }
+}
+
+extension MyPageInformationPropertiable {
+  
+}
+
+struct MyPageInformationProperty: MyPageInformationPropertiable {
+  var name: String?
+  var birthDate: Date?
+  var gender: Gender?
+  
+  init(name: String? = nil, birthDate: Date? = nil, gender: Gender? = nil) {
+    self.name = name
+    self.birthDate = birthDate
+    self.gender = gender
+  }
+}

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
@@ -19,22 +19,65 @@ struct MyPageEditHelper: Equatable {
     originalValue = .init()
     editedValue = .init()
   }
+
+  var selectedGender: Gender? {
+    // 수정된 Gedner가 있을 때
+    if editedValue.gender == nil {
+      return originalValue.gender
+    }
+    // 없을 때
+    return editedValue.gender
+  }
+
+  var namePromptText: String {
+    return originalValue.name == "" ? "김수수" : originalValue.name
+  }
+
+  var birthDayNotEditedText: String {
+    return textTo(date: originalValue.birthDate)
+  }
+
+  /// Date를 화면에 표시가능한 Text로 변환해 줍니다.
+  func textTo(date: Date?) -> String {
+    if date == nil {
+      return "2024년"
+    }
+    return "2024년"
+  }
+
+  func isEditedBirthDay() -> Bool {
+    return !(editedValue.birthDate == nil)
+  }
+
+  mutating func editName(text: String) {
+    editedValue.name = text
+  }
 }
 
 // MARK: - Gender
 
-enum Gender: Int, Identifiable, Equatable, CaseIterable {
+enum Gender: Int, Identifiable, Equatable, CaseIterable, CustomStringConvertible {
   case male = 0
   case female
 
   var id: Int { return rawValue }
+
+  /// Button의 타이틀에 사용됩니다.
+  var description: String {
+    switch self {
+    case .male:
+      "남자"
+    case .female:
+      "여자"
+    }
+  }
 }
 
 // MARK: - MyPageInformationPropertiable
 
 protocol MyPageInformationPropertiable: Equatable {
   /// 내정보에 표시되는 이름입니다.
-  var name: String? { get set }
+  var name: String { get set }
 
   /// 내정보에 표시되는 생일 입니다.
   var birthDate: Date? { get set }
@@ -46,11 +89,11 @@ protocol MyPageInformationPropertiable: Equatable {
 // MARK: - MyPageInformationProperty
 
 struct MyPageInformationProperty: MyPageInformationPropertiable, Equatable {
-  var name: String?
+  var name: String
   var birthDate: Date?
   var gender: Gender?
 
-  init(name: String? = nil, birthDate: Date? = nil, gender: Gender? = nil) {
+  init(name: String = "", birthDate: Date? = nil, gender: Gender? = nil) {
     self.name = name
     self.birthDate = birthDate
     self.gender = gender

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
@@ -8,39 +8,48 @@
 
 import Foundation
 
-struct MyPageEditHelper {
+// MARK: - MyPageEditHelper
+
+struct MyPageEditHelper: Equatable {
   var originalValue: MyPageInformationProperty
   var editedValue: MyPageInformationProperty
+  
+  init(){
+    //TODO: 초기값 지정할 수 있는 로직 생성
+    originalValue = .init()
+    editedValue = .init()
+  }
 }
 
-enum Gender: Int, Identifiable  {
+// MARK: - Gender
+
+enum Gender: Int, Identifiable, Equatable, CaseIterable {
   case male = 0
   case female
-  
+
   var id: Int { return rawValue }
 }
 
-protocol MyPageInformationPropertiable {
-  
+// MARK: - MyPageInformationPropertiable
+
+protocol MyPageInformationPropertiable: Equatable {
   /// 내정보에 표시되는 이름입니다.
-  var name: String? { get set}
-  
+  var name: String? { get set }
+
   /// 내정보에 표시되는 생일 입니다.
-  var birthDate: Date? {get set}
-  
+  var birthDate: Date? { get set }
+
   /// 내정보에 표시되는 성별 입니다.
   var gender: Gender? { get set }
 }
 
-extension MyPageInformationPropertiable {
-  
-}
+// MARK: - MyPageInformationProperty
 
-struct MyPageInformationProperty: MyPageInformationPropertiable {
+struct MyPageInformationProperty: MyPageInformationPropertiable, Equatable {
   var name: String?
   var birthDate: Date?
   var gender: Gender?
-  
+
   init(name: String? = nil, birthDate: Date? = nil, gender: Gender? = nil) {
     self.name = name
     self.birthDate = birthDate

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
@@ -37,12 +37,32 @@ struct MyPageEditHelper: Equatable {
     return textTo(date: originalValue.birthDate)
   }
 
+  var birthDayDate: Date? {
+    guard let date = editedValue.birthDate else {
+      return originalValue.birthDate
+    }
+    return date
+  }
+
+  var birthDayText: String {
+    if editedValue.birthDate == nil {
+      return textTo(date: originalValue.birthDate)
+    }
+    return textTo(date: editedValue.birthDate)
+  }
+
   /// Date를 화면에 표시가능한 Text로 변환해 줍니다.
-  func textTo(date: Date?) -> String {
-    if date == nil {
+  private func textTo(date: Date?) -> String {
+    guard let date else {
       return "2024년"
     }
-    return "2024년"
+    return SelectYearItemDateFormatter.yearStringFrom(date: date)
+  }
+
+  mutating func setEditDate(by value: String) {
+    if let date = SelectYearItemDateFormatter.dateFrom(string: value) {
+      editedValue.birthDate = date
+    }
   }
 
   func isEditedBirthDay() -> Bool {

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditHelper.swift
@@ -13,9 +13,9 @@ import Foundation
 struct MyPageEditHelper: Equatable {
   var originalValue: MyPageInformationProperty
   var editedValue: MyPageInformationProperty
-  
-  init(){
-    //TODO: 초기값 지정할 수 있는 로직 생성
+
+  init() {
+    // TODO: 초기값 지정할 수 있는 로직 생성
     originalValue = .init()
     editedValue = .init()
   }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditRouter.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditRouter.swift
@@ -1,17 +1,25 @@
 //
-//  MyPageInformationRouter.swift
+//  MyPageEditRouter.swift
 //  MyPage
 //
-//  Created by MaraMincho on 5/12/24.
+//  Created by MaraMincho on 5/15/24.
 //  Copyright © 2024 com.oksusu. All rights reserved.
 //
 
 import Combine
+import ComposableArchitecture
+import Designsystem
 import SwiftUI
-import UIKit
 
-final class MyPageInformationRouter: UIHostingController<MyPageInformationView> {
+final class MyPageEditRouter: UIHostingController<MyPageEditView> {
+  // MARK: RouterSubscription
+
   var subscription: AnyCancellable? = nil
+
+  // MARK: Reducer
+
+  let reducer: MyPageEdit
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -19,21 +27,17 @@ final class MyPageInformationRouter: UIHostingController<MyPageInformationView> 
       .routingPublisher
       .sink { [weak self] path in
         switch path {
-        // 프로필 편집 뷰로 이동
-        case .editProfile:
-          let vc = MyPageEditRouter()
-          self?.navigationController?.pushViewController(vc, animated: true)
-          return
+        case .dismiss:
+          self?.navigationController?.popViewController(animated: true)
         }
       }
   }
 
-  var reducer: MyPageInformation
   init() {
-    let reducer = MyPageInformation()
+    let reducer = MyPageEdit()
     self.reducer = reducer
 
-    super.init(rootView: MyPageInformationView(store: .init(initialState: MyPageInformation.State()) {
+    super.init(rootView: MyPageEditView(store: .init(initialState: MyPageEdit.State()) {
       reducer
     }))
   }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -82,7 +82,7 @@ struct MyPageEditView: View {
         .foregroundStyle(SSColor.gray60)
 
       Spacer()
-      Text(store.helper.birthDayNotEditedText)
+      Text(store.helper.birthDayText)
         .frame(maxWidth: .infinity, alignment: .trailing)
         .modifier(SSTypoModifier(.title_xs))
         .foregroundStyle(store.helper.isEditedBirthDay() ? SSColor.gray100 : SSColor.gray40)
@@ -139,10 +139,12 @@ struct MyPageEditView: View {
       store.send(.view(.onAppear(true)))
     }
     .sheet(isPresented: $store.selectYearIsPresented.sending(\.view.selectedYearItem)) {
-      SelectYearBottomSheetView(store: store.scope(state: \.selectYear, action: \.scope.selectYear))
-        .presentationDetents([.height(240), .medium, .large])
-        .presentationContentInteraction(.scrolls) // TODO: PR에 작성하기
-        .presentationDragIndicator(.automatic)
+      IfLetStore(store.scope(state: \.selectYear, action: \.scope.selectYear)) { store in
+        SelectYearBottomSheetView(store: store)
+          .presentationDetents([.height(240), .medium, .large])
+          .presentationContentInteraction(.scrolls) // TODO: PR에 작성하기
+          .presentationDragIndicator(.automatic)
+      }
     }
     .safeAreaInset(edge: .bottom) { makeTabBar() }
   }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -55,11 +55,21 @@ struct MyPageEditView: View {
   @ViewBuilder
   private func makeNameTextfieldItem() -> some View {
     HStack {
-      Text(Constants.nameCellTitle)
-        .modifier(SSTypoModifier(.title_xxs))
-        .foregroundStyle(SSColor.gray60)
+      HStack(alignment: .top, spacing: 4) {
+        Text(Constants.nameCellTitle)
+          .modifier(SSTypoModifier(.title_xxs))
+          .foregroundStyle(SSColor.gray60)
 
-      Spacer()
+        VStack(spacing: 0) {
+          Spacer()
+            .frame(height: 4)
+          SSColor
+            .red60
+            .clipShape(Circle())
+            .frame(width: 4, height: 4)
+        }
+      }
+
       TextField(
         "",
         text: $store.helper.editedValue.name.sending(\.view.nameEdited),
@@ -70,7 +80,7 @@ struct MyPageEditView: View {
       .multilineTextAlignment(.trailing)
       .frame(maxWidth: .infinity, alignment: .trailing)
     }
-    .frame(maxWidth: .infinity)
+    .frame(maxWidth: .infinity, maxHeight: 28)
     .padding(.vertical, Metrics.itemVerticalSpacing)
   }
 
@@ -87,7 +97,7 @@ struct MyPageEditView: View {
         .modifier(SSTypoModifier(.title_xs))
         .foregroundStyle(store.helper.isEditedBirthDay() ? SSColor.gray100 : SSColor.gray40)
     }
-    .frame(maxWidth: .infinity)
+    .frame(maxWidth: .infinity, maxHeight: 28)
     .padding(.vertical, Metrics.itemVerticalSpacing)
     .onTapGesture {
       store.send(.view(.selectedYearItem(true)))
@@ -120,6 +130,7 @@ struct MyPageEditView: View {
         }
       }
     }
+    .frame(maxWidth: .infinity, maxHeight: 28)
     .padding(.vertical, Metrics.itemVerticalSpacing)
   }
 

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -21,6 +21,17 @@ struct MyPageEditView: View {
   private func makeContentView() -> some View {
     VStack(spacing: 0) {}
   }
+  
+  @ViewBuilder
+  private func makeTabBar() -> some View {
+    SSTabbar(store: store.scope(state: \.tabBar, action: \.scope.tabBar))
+      .background {
+        Color.white
+      }
+      .ignoresSafeArea()
+      .frame(height: 56)
+      .toolbar(.hidden, for: .tabBar)
+  }
 
   var body: some View {
     ZStack {
@@ -28,6 +39,7 @@ struct MyPageEditView: View {
         .gray15
         .ignoresSafeArea()
       VStack(spacing: 0) {
+        HeaderView(store: store.scope(state: \.header, action: \.scope.header))
         makeContentView()
       }
     }
@@ -35,6 +47,7 @@ struct MyPageEditView: View {
     .onAppear {
       store.send(.view(.onAppear(true)))
     }
+    .safeAreaInset(edge: .bottom) { makeTabBar() }
   }
 
   private enum Metrics {}

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -21,7 +21,7 @@ struct MyPageEditView: View {
   private func makeContentView() -> some View {
     VStack(spacing: 0) {}
   }
-  
+
   @ViewBuilder
   private func makeTabBar() -> some View {
     SSTabbar(store: store.scope(state: \.tabBar, action: \.scope.tabBar))

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -153,7 +153,7 @@ struct MyPageEditView: View {
       IfLetStore(store.scope(state: \.selectYear, action: \.scope.selectYear)) { store in
         SelectYearBottomSheetView(store: store)
           .presentationDetents([.height(240), .medium, .large])
-          .presentationContentInteraction(.scrolls) // TODO: PR에 작성하기
+          .presentationContentInteraction(.scrolls)
           .presentationDragIndicator(.automatic)
       }
     }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -19,7 +19,26 @@ struct MyPageEditView: View {
 
   @ViewBuilder
   private func makeContentView() -> some View {
-    VStack(spacing: 0) {}
+    VStack(spacing: 0) {
+      makeProfileView()
+
+      makeNameTextfieldItem()
+
+      makeBirthDayItem()
+
+      makeGenderItem()
+
+      Spacer()
+    }
+  }
+
+  @ViewBuilder
+  private func makeProfileView() -> some View {
+    SSImage
+      .mypageSusu
+      .frame(width: 88, height: 88)
+      .clipShape(.circle)
+      .padding(.vertical, Metrics.profileVerticalSpacing)
   }
 
   @ViewBuilder
@@ -33,14 +52,83 @@ struct MyPageEditView: View {
       .toolbar(.hidden, for: .tabBar)
   }
 
+  @ViewBuilder
+  private func makeNameTextfieldItem() -> some View {
+    HStack {
+      Text(Constants.nameCellTitle)
+        .modifier(SSTypoModifier(.title_xxs))
+        .foregroundStyle(SSColor.gray60)
+
+      Spacer()
+      TextField(
+        "",
+        text: $store.helper.editedValue.name.sending(\.view.nameEdited),
+        prompt: Text(store.helper.namePromptText).foregroundStyle(SSColor.gray40)
+      )
+      .modifier(SSTypoModifier(.title_xs))
+      .foregroundStyle(SSColor.gray100)
+      .multilineTextAlignment(.trailing)
+      .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, Metrics.itemVerticalSpacing)
+  }
+
+  @ViewBuilder
+  private func makeBirthDayItem() -> some View {
+    HStack(spacing: 0) {
+      Text(Constants.birthdayCellTitle)
+        .modifier(SSTypoModifier(.title_xxs))
+        .foregroundStyle(SSColor.gray60)
+
+      Spacer()
+      Text(store.helper.birthDayNotEditedText)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .modifier(SSTypoModifier(.title_xs))
+        .foregroundStyle(store.helper.isEditedBirthDay() ? SSColor.gray100 : SSColor.gray40)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, Metrics.itemVerticalSpacing)
+  }
+
+  @ViewBuilder
+  private func makeGenderItem() -> some View {
+    HStack(spacing: 0) {
+      Text(Constants.genderCellTitle)
+        .modifier(SSTypoModifier(.title_xxs))
+        .foregroundStyle(SSColor.gray60)
+
+      Spacer()
+      HStack(spacing: 8) {
+        ForEach(Gender.allCases, id: \.id) { gender in
+          let isSelected = store.helper.selectedGender == gender
+          SSButton(
+            .init(
+              size: .sh32,
+              status: isSelected ? .active : .inactive,
+              style: .filled,
+              color: .orange,
+              buttonText: gender.description,
+              frame: .init(maxWidth: 116)
+            )
+          ) {
+            store.send(.view(.selectGender(gender)))
+          }
+        }
+      }
+    }
+    .padding(.vertical, Metrics.itemVerticalSpacing)
+  }
+
   var body: some View {
     ZStack {
       SSColor
-        .gray15
+        .gray10
         .ignoresSafeArea()
       VStack(spacing: 0) {
         HeaderView(store: store.scope(state: \.header, action: \.scope.header))
         makeContentView()
+          .padding(.horizontal, Metrics.horizontalSpacing)
       }
     }
     .navigationBarBackButtonHidden()
@@ -50,7 +138,15 @@ struct MyPageEditView: View {
     .safeAreaInset(edge: .bottom) { makeTabBar() }
   }
 
-  private enum Metrics {}
+  private enum Metrics {
+    static let profileVerticalSpacing: CGFloat = 16
+    static let horizontalSpacing: CGFloat = 16
+    static let itemVerticalSpacing: CGFloat = 16
+  }
 
-  private enum Constants {}
+  private enum Constants {
+    static let nameCellTitle: String = "이름"
+    static let birthdayCellTitle: String = "생년월일"
+    static let genderCellTitle: String = "성별"
+  }
 }

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -1,0 +1,43 @@
+//
+//  MyPageEditView.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Designsystem
+import SwiftUI
+
+struct MyPageEditView: View {
+  // MARK: Reducer
+
+  @Bindable
+  var store: StoreOf<MyPageEdit>
+
+  // MARK: Content
+
+  @ViewBuilder
+  private func makeContentView() -> some View {
+    VStack(spacing: 0) {}
+  }
+
+  var body: some View {
+    ZStack {
+      SSColor
+        .gray15
+        .ignoresSafeArea()
+      VStack(spacing: 0) {
+        makeContentView()
+      }
+    }
+    .navigationBarBackButtonHidden()
+    .onAppear {
+      store.send(.view(.onAppear(true)))
+    }
+  }
+
+  private enum Metrics {}
+
+  private enum Constants {}
+}

--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEditView.swift
@@ -89,6 +89,9 @@ struct MyPageEditView: View {
     }
     .frame(maxWidth: .infinity)
     .padding(.vertical, Metrics.itemVerticalSpacing)
+    .onTapGesture {
+      store.send(.view(.selectedYearItem(true)))
+    }
   }
 
   @ViewBuilder
@@ -134,6 +137,12 @@ struct MyPageEditView: View {
     .navigationBarBackButtonHidden()
     .onAppear {
       store.send(.view(.onAppear(true)))
+    }
+    .sheet(isPresented: $store.selectYearIsPresented.sending(\.view.selectedYearItem)) {
+      SelectYearBottomSheetView(store: store.scope(state: \.selectYear, action: \.scope.selectYear))
+        .presentationDetents([.height(240), .medium, .large])
+        .presentationContentInteraction(.scrolls) // TODO: PR에 작성하기
+        .presentationDragIndicator(.automatic)
     }
     .safeAreaInset(edge: .bottom) { makeTabBar() }
   }

--- a/Projects/Feature/MyPage/Sources/MyPageInformation/MyPageInformation.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageInformation/MyPageInformation.swift
@@ -32,15 +32,14 @@ struct MyPageInformation: Reducer {
     case async(AsyncAction)
     case scope(ScopeAction)
     case delegate(DelegateAction)
+    case route(Routing)
   }
 
   enum ViewAction: Equatable {
     case onAppear(Bool)
   }
 
-  enum InnerAction: Equatable {
-    case routEditProfile
-  }
+  enum InnerAction: Equatable {}
 
   enum AsyncAction: Equatable {}
 
@@ -79,11 +78,12 @@ struct MyPageInformation: Reducer {
 
       case .scope(.listItems):
         return .none
-      case .inner(.routEditProfile):
-        routingPublisher.send(.editProfile)
-        return .none
 
       case .scope(.tabBar):
+        return .none
+
+      case let .route(destination):
+        routingPublisher.send(destination)
         return .none
       }
     }

--- a/Projects/Feature/MyPage/Sources/MyPageInformation/MyPageInformation.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageInformation/MyPageInformation.swift
@@ -70,8 +70,8 @@ struct MyPageInformation: Reducer {
       case let .view(.onAppear(isAppear)):
         state.isOnAppear = isAppear
         return .none
-      case .scope(.header(.tappedSearchButton)):
-        return .none
+      case .scope(.header(.tappedTextButton)):
+        return .send(.route(.editProfile))
 
       case .scope(.header):
         return .none

--- a/Projects/Feature/MyPage/Sources/MyPageMain/MyPageMain.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageMain/MyPageMain.swift
@@ -38,11 +38,13 @@ struct MyPageMain {
     case async(AsyncAction)
     case scope(ScopeAction)
     case delegate(DelegateAction)
+    case route(Routing)
   }
 
   enum ViewAction: Equatable {
     case onAppear(Bool)
     case tappedFeedbackButton
+    case tappedMyPageInformationSection
   }
 
   enum InnerAction: Equatable {
@@ -147,6 +149,7 @@ struct MyPageMain {
         case .logout:
           routingPublisher.send(.logout)
           return .none
+
         case .resign:
           routingPublisher.send(.resign)
           return .none
@@ -155,6 +158,13 @@ struct MyPageMain {
       // TODO: Routing FeedBackPage
       case .view(.tappedFeedbackButton):
         return .none
+
+      case let .route(next):
+        routingPublisher.send(next)
+        return .none
+
+      case .view(.tappedMyPageInformationSection):
+        return .send(.route(.myPageInformation))
       }
     }
     .subFeatures0()

--- a/Projects/Feature/MyPage/Sources/MyPageMain/ProfileMainView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageMain/ProfileMainView.swift
@@ -113,6 +113,9 @@ struct MyPageMainView: View {
     .padding(.vertical, Metrics.makeMyNameAndMyInformationButtonViewVerticalSpacing)
     .frame(maxWidth: .infinity)
     .background(SSColor.gray10)
+    .onTapGesture {
+      store.send(.route(.myPageInformation))
+    }
   }
 
   @ViewBuilder

--- a/Projects/Feature/MyPage/Sources/MyPageMain/ProfileMainView.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageMain/ProfileMainView.swift
@@ -109,6 +109,7 @@ struct MyPageMainView: View {
           .envelopeForwardArrow
       }
     }
+    .padding(.horizontal, Metrics.horizontalSpacing)
     .padding(.vertical, Metrics.makeMyNameAndMyInformationButtonViewVerticalSpacing)
     .frame(maxWidth: .infinity)
     .background(SSColor.gray10)
@@ -146,6 +147,7 @@ struct MyPageMainView: View {
 
   private enum Metrics {
     static let makeMyNameAndMyInformationButtonViewVerticalSpacing: CGFloat = 16
+    static let horizontalSpacing: CGFloat = 16
   }
 
   private enum Constants {

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheet.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheet.swift
@@ -12,16 +12,17 @@ import Foundation
 struct SelectYearBottomSheet {
   @ObservableState
   struct State: Equatable {
-    var isOnAppear = false
     var listItems: SelectYearListProperty = .init()
 
     var originalYear: Date?
     var originalYearString: String?
-    @Shared var selectedYear: Date?
 
-    init(originalYear: Date?, selectedYear: Shared<Date?>) {
+    init(originalYear: Date?) {
+      guard let originalYear else {
+        return
+      }
       self.originalYear = originalYear
-      _selectedYear = selectedYear
+      originalYearString = SelectYearItemDateFormatter.yearStringFrom(date: originalYear)
     }
   }
 
@@ -38,7 +39,7 @@ struct SelectYearBottomSheet {
   var body: some Reducer<State, Action> {
     Reduce { _, action in
       switch action {
-      case let .tappedYear(title):
+      default:
         return .none
       }
     }

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheet.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheet.swift
@@ -1,0 +1,46 @@
+//
+//  SelectYearBottomSheet.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct SelectYearBottomSheet {
+  @ObservableState
+  struct State: Equatable {
+    var isOnAppear = false
+    var listItems: SelectYearListProperty = .init()
+
+    var originalYear: Date?
+    var originalYearString: String?
+    @Shared var selectedYear: Date?
+
+    init(originalYear: Date?, selectedYear: Shared<Date?>) {
+      self.originalYear = originalYear
+      _selectedYear = selectedYear
+    }
+  }
+
+  enum Action: Equatable {
+    case tappedYear(String)
+  }
+
+  enum ViewAction: Equatable {
+    case onAppear(Bool)
+  }
+
+  @Dependency(\.dismiss) var dismiss
+
+  var body: some Reducer<State, Action> {
+    Reduce { _, action in
+      switch action {
+      case let .tappedYear(title):
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheetView.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheetView.swift
@@ -1,0 +1,56 @@
+//
+//  SelectYearBottomSheetView.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+import ComposableArchitecture
+import Designsystem
+import SwiftUI
+
+struct SelectYearBottomSheetView: View {
+  // MARK: Reducer
+
+  @Bindable
+  var store: StoreOf<SelectYearBottomSheet>
+
+  // MARK: Content
+
+  @ViewBuilder
+  private func makeContentView() -> some View {
+    VStack(spacing: 0) {
+      ScrollView {
+        LazyVStack(spacing: 0) {
+          ForEach(store.listItems.items) { item in
+            Text(item.dateTitle)
+              .foregroundStyle(item.dateTitle == store.originalYearString ? SSColor.gray100 : SSColor.gray30)
+              .padding(.vertical, Metrics.itemVerticalSpacing)
+              .onTapGesture {
+                store.send(.tappedYear(item.dateTitle))
+              }
+          }
+        }
+      }
+    }
+  }
+
+  var body: some View {
+    ZStack {
+      SSColor
+        .gray10
+        .ignoresSafeArea()
+      VStack(spacing: 0) {
+        makeContentView()
+      }
+    }
+    .navigationBarBackButtonHidden()
+    .onAppear {}
+  }
+
+  private enum Metrics {
+    static let itemVerticalSpacing: CGFloat = 12
+  }
+
+  private enum Constants {}
+}

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheetView.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearBottomSheetView.swift
@@ -21,9 +21,12 @@ struct SelectYearBottomSheetView: View {
   private func makeContentView() -> some View {
     VStack(spacing: 0) {
       ScrollView {
+        Spacer()
+          .frame(height: 16)
         LazyVStack(spacing: 0) {
           ForEach(store.listItems.items) { item in
             Text(item.dateTitle)
+              .modifier(SSTypoModifier(.title_xxs))
               .foregroundStyle(item.dateTitle == store.originalYearString ? SSColor.gray100 : SSColor.gray30)
               .padding(.vertical, Metrics.itemVerticalSpacing)
               .onTapGesture {

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearItem.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearItem.swift
@@ -1,0 +1,31 @@
+//
+//  SelectYearItem.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Foundation
+
+struct SelectYearListProperty: Equatable {
+  let items: [SelectYearItem]
+  init() {
+    let nowYear = Int(SelectYearItemDateFormatter.yearStringFrom(date: .now))
+    let maxYearRange = nowYear ?? 2024
+    items = (1950 ... maxYearRange).map { .init(dateTitle: $0.description) }.reversed()
+  }
+
+  struct SelectYearItem: Identifiable, Equatable {
+    let id: UUID = .init()
+    var date: Date? {
+      SelectYearItemDateFormatter.dateFrom(string: dateTitle)
+    }
+
+    var dateTitle: String
+
+    init(dateTitle: String) {
+      self.dateTitle = dateTitle
+    }
+  }
+}

--- a/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearItemDateFormatter.swift
+++ b/Projects/Feature/MyPage/Sources/SelectYearSheet/SelectYearItemDateFormatter.swift
@@ -1,0 +1,27 @@
+//
+//  SelectYearItemDateFormatter.swift
+//  MyPage
+//
+//  Created by MaraMincho on 5/15/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Foundation
+
+final class SelectYearItemDateFormatter {
+  private init() {}
+
+  private static let dateFormatter: DateFormatter = {
+    var formatter = DateFormatter()
+    formatter.dateFormat = "yyyy"
+    return formatter
+  }()
+
+  static func yearStringFrom(date: Date) -> String {
+    return dateFormatter.string(from: date)
+  }
+
+  static func dateFrom(string val: String) -> Date? {
+    return dateFormatter.date(from: val)
+  }
+}


### PR DESCRIPTION
## 작업 내용

- [ ] 마이페이지 편집 뷰 구현 

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)

![Simulator Screen Recording - iPhone 15 Pro - 2024-05-15 at 20 07 09](https://github.com/ok-su-su/iOS/assets/103064352/028d5093-9ecd-46c4-bac8-2d306e833388)




<br/><br/><br/>


## 고민점 및 해결 방법

### BottomSheet ScrollView에 대한 고촬

BottomSheet ScrollView를 구현했습니다. 그런데 responderChain이 bottomSheetScrollView에 있지 않고 drag의 responderchain이 scollView에 가지 않았습니다. 저와 같은 문제를 갖고 있는 사람들이 있나 구글링을 하였지만 찾지 못했습니다. 공식문서 뒤져서 `.presentationContentInteraction(.scrolls)`을 찾았고, responderChain이 view내부로 들어가게 하는 코드인것을 알았습니다. 


<br/>

### UIHostingController와 TCA의 화면전환
ProfileView의 아키텍쳐는 다른 모듈과는 다르게 했습니다. 이곳저곳 화면전환이 많이 될 것 같아 Router을 따뤄 둬 화면전환을 관장하는 객체를 따로 만들었습니다. navigationController를 통한 화면전환이다보니 dismiss를 Reducer에서 하게되면 에러가 발생하는 경우가 있었습니다. 이를 해결하고자 나중에 Router라는 공통 모듈로서 dismiss를 정의할 예정입니다. 









<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)

N/A


<br/><br/><br/>
## 레퍼런스
https://developer.apple.com/documentation/swiftui/view/presentationcontentinteraction(_:)



<br/><br/><br/>
close: #86
