### PR TITLE
[Bug] Sent Envelope 버그 수정(봉투 터치 영역 조정, 봉투 Padding 및 Badge 크기 조정)

### DIFF
--- a/Projects/Feature/Sent/Sources/Envelope/EnvelopeView.swift
+++ b/Projects/Feature/Sent/Sources/Envelope/EnvelopeView.swift
@@ -20,7 +20,7 @@ struct EnvelopeView: View {
   private func makeHeaderView() -> some View {
     HStack(spacing: 0) {
       // 이름
-      Text(store.envelopeProperty.envelopeTargetUserNameText) // TODO:
+      Text(store.envelopeProperty.envelopeTargetUserNameText)
         .modifier(SSTypoModifier(.title_xs))
         .padding(.trailing, Metrics.textAndBadgeSpacing)
         .foregroundStyle(SSColor.gray100)
@@ -44,7 +44,6 @@ struct EnvelopeView: View {
   @ViewBuilder
   private func makeDetailPressButton() -> some View {
     SSImage.envelopeDownArrow
-      .resizable()
       .frame(width: 24, height: 24)
       .rotationEffect(.degrees(store.showDetail ? 180 : 0))
   }

--- a/Projects/Feature/Sent/Sources/Envelope/EnvelopeView.swift
+++ b/Projects/Feature/Sent/Sources/Envelope/EnvelopeView.swift
@@ -36,14 +36,17 @@ struct EnvelopeView: View {
       Button {
         store.send(.tappedDetailButton)
       } label: {
-        if store.showDetail == false {
-          SSImage.envelopeDownArrow
-        } else {
-          SSImage.envelopeDownArrow
-            .rotationEffect(.degrees(180))
-        }
+        makeDetailPressButton()
       }
     }
+  }
+
+  @ViewBuilder
+  private func makeDetailPressButton() -> some View {
+    SSImage.envelopeDownArrow
+      .resizable()
+      .frame(width: 24, height: 24)
+      .rotationEffect(.degrees(store.showDetail ? 180 : 0))
   }
 
   @ViewBuilder

--- a/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressProperty.swift
+++ b/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressProperty.swift
@@ -29,11 +29,11 @@ struct EnvelopePriceProgressProperty: Equatable {
   }
 
   var leadingPriceText: String {
-    return CustomNumberFormatter.formattedByThreeZero(leadingPriceValue) ?? ""
+    return CustomNumberFormatter.formattedByThreeZero(leadingPriceValue, subFixString: "원") ?? ""
   }
 
   var trailingPriceText: String {
-    return CustomNumberFormatter.formattedByThreeZero(trailingPriceValue) ?? ""
+    return CustomNumberFormatter.formattedByThreeZero(trailingPriceValue, subFixString: "원") ?? ""
   }
 
   static func makeFakeData() -> Self {

--- a/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressView.swift
+++ b/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressView.swift
@@ -70,7 +70,7 @@ struct EnvelopePriceProgressView: View {
 
   @ViewBuilder
   private func makeContentView() -> some View {
-    VStack(spacing: 0) {
+    VStack(spacing: 4) {
       makeMiddleView()
       makeProgressBarView()
       makeBottomView()

--- a/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressView.swift
+++ b/Projects/Feature/Sent/Sources/EnvelopePriceProgress/EnvelopePriceProgressView.swift
@@ -19,13 +19,13 @@ struct EnvelopePriceProgressView: View {
   private func makeMiddleView() -> some View {
     HStack {
       Text(store.envelopePriceProgressProperty.leadingDescriptionText)
-        .modifier(SSTypoModifier(.text_xxxs))
+        .applySSFont(.title_xxxs)
         .foregroundColor(SSColor.gray90)
 
       Spacer()
 
       Text(store.envelopePriceProgressProperty.trailingDescriptionText)
-        .modifier(SSTypoModifier(.text_xxxs))
+        .applySSFont(.title_xxxs)
         .foregroundColor(SSColor.gray60)
     }
   }
@@ -52,16 +52,14 @@ struct EnvelopePriceProgressView: View {
   @ViewBuilder
   private func makeBottomView() -> some View {
     HStack {
-      // TODO: API 호출 된 Value 로 변경
       Text(store.envelopePriceProgressProperty.leadingPriceText)
-        .modifier(SSTypoModifier(.text_xxxs))
+        .applySSFont(.title_xxxs)
         .foregroundColor(SSColor.gray90)
 
       Spacer()
 
-      // TODO: API 호출 된 Value 로 변경
       Text(store.envelopePriceProgressProperty.trailingPriceText)
-        .modifier(SSTypoModifier(.text_xxxs))
+        .applySSFont(.title_xxxs)
         .foregroundColor(SSColor.gray60)
     }
   }

--- a/Projects/Share/Designsystem/Sources/SSBadges.swift
+++ b/Projects/Share/Designsystem/Sources/SSBadges.swift
@@ -21,6 +21,15 @@ public struct SmallBadgeProperty {
     self.badgeColor = badgeColor
   }
 
+  var badgeHeight: CGFloat {
+    switch size {
+    case .small:
+      24
+    case .xSmall:
+      20
+    }
+  }
+
   public enum BadgeColor: String {
     case gray20
     case orange60
@@ -110,6 +119,6 @@ public struct SmallBadge: View {
     .background {
       property.backgroundColor
     }
-    .cornerRadius(4)
+    .clipShape(RoundedRectangle(cornerRadius: 4))
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] Sent Envelope 버그 수정(봉투 터치 영역 조정, 봉투 Padding 및 Badge 크기 조정)

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)


|View|View|
|:-:|:-:|
|![image](https://github.com/ok-su-su/iOS/assets/103064352/7f7ad755-9eba-4ba9-93fc-c9f38327fdc0)|![image](https://github.com/ok-su-su/iOS/assets/103064352/cda88693-8476-4c6d-8c54-08d86d7dd8ca)|


<br/><br/><br/>


## 고민점 및 해결 방법








<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)




<br/><br/><br/>
## 레퍼런스



<br/><br/><br/>
close: #235
close: #258
