### PR TITLE
[BugFix] 봉투 편집 후 봉투 상세로 돌아왔을 때 경조사 카테고리가 ‘이벤트 네임’으로 노출되는 버그

### DIFF
--- a/Projects/Feature/SSEnvelope/Sources/Network/EnvelopeNetwork.swift
+++ b/Projects/Feature/SSEnvelope/Sources/Network/EnvelopeNetwork.swift
@@ -26,7 +26,7 @@ struct EnvelopeNetwork {
       type: data.envelope.type,
       ledgerID: nil,
       price: data.envelope.amount,
-      eventName: data.category.customCategory != nil ? data.category.customCategory! : data.category.category,
+      eventName: data.category.customCategory ?? data.category.category,
       friendID: data.friend.id,
       name: data.friend.name,
       relation: data.friendRelationship.customRelation != nil ? data.friendRelationship.customRelation! : data.relationship.relation,
@@ -80,7 +80,7 @@ struct EnvelopeNetwork {
       type: dto.envelope.type,
       ledgerID: nil,
       price: dto.envelope.amount,
-      eventName: "이벤트 네임", // TODO: Category 수정
+      eventName: dto.category.customCategory ?? dto.category.category,
       friendID: dto.friend.id,
       name: dto.friend.name,
       relation: dto.friendRelationship.customRelation ?? dto.relationship.relation,

--- a/Projects/Feature/SSEnvelope/Sources/NetworkResponse/CreateAndUpdateEnvelopeRequest.swift
+++ b/Projects/Feature/SSEnvelope/Sources/NetworkResponse/CreateAndUpdateEnvelopeRequest.swift
@@ -15,12 +15,14 @@ struct CreateAndUpdateEnvelopeResponse: Decodable {
   var friend: FriendModel
   var friendRelationship: FriendRelationshipModel
   var relationship: RelationshipModel
+  var category: CategoryWithCustomModel
 
   enum CodingKeys: CodingKey {
     case envelope
     case friend
     case friendRelationship
     case relationship
+    case category
   }
 }
 


### PR DESCRIPTION
## 작업 내용

- [x] Network Edit Response Property 변경
- [x] ResponseDTO 를 통한 ViewProperty 로직 변경

<br/><br/><br/>
close: #350
close: #
