### PR TITLE
[BugFix] 스크롤 뷰와 탭바 여백 제거

### DIFF
--- a/Projects/Share/Designsystem/Sources/ScrollViewWithFilterItems.swift
+++ b/Projects/Share/Designsystem/Sources/ScrollViewWithFilterItems.swift
@@ -159,6 +159,5 @@ public struct ScrollViewWithFilterItems<Header: View, Content: View>: View {
       }
     }
     .scrollIndicators(.hidden)
-    .clipped()
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] ScrollViewWithHeader 의 Clip() modifier 제거 

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)


|View|View|
|:-:|:-:|
|![IMG_9834 2](https://github.com/user-attachments/assets/f3f650f6-93b7-46e7-9958-d4710b4bf16d)| ![IMG_9835 2](https://github.com/user-attachments/assets/f2e0a943-450e-4644-8c62-be43172d6558)|


<br/><br/><br/>


## 고민점 및 해결 방법








<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)




<br/><br/><br/>
## 레퍼런스



<br/><br/><br/>
close: #
close: #
