### PR TITLE
[Feature] 마이페이지 및, Onboarding시 출생년도 미선택 항목 추가, ScrollView 버그 수정 

### DIFF
--- a/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageEdit/MyPageEdit.swift
@@ -149,9 +149,11 @@ struct MyPageEdit {
     case .selectedYearItem:
       state.bottomSheet = .init(
         items: .default,
-        selectedItem: state.$selectedBottomSheetItem
+        selectedItem: state.$selectedBottomSheetItem,
+        deselectItem: .notSelectedItem
       )
       return .none
+
     case .tappedEditConfirmButton:
       return .send(.inner(.updateUserInformation))
     }
@@ -191,6 +193,12 @@ struct MyPageEdit {
       case .scope(.toast):
         return .none
 
+      case let .scope(.bottomSheet(.presented(.changedItem(item)))):
+        if item == .notSelectedItem {
+          state.selectedBottomSheetItem = nil
+        }
+        return .none
+
       case .scope(.bottomSheet(_)):
         return .none
 
@@ -223,6 +231,7 @@ struct MyPageEdit {
           MyPageSharedState.shared.setUserInfoResponseDTO(dto)
           await send(.route(.dismiss))
         }
+
       case .scope(.genderSection(_)):
         return .none
       }
@@ -244,9 +253,17 @@ extension Reducer where Self.State == MyPageEdit.State, Self.Action == MyPageEdi
 
 extension [SelectYearBottomSheetItem] {
   static var `default`: Self {
-    return (1930 ... Int(CustomDateFormatter.getYear(from: .now))!)
+    let defaultItems: [SelectYearBottomSheetItem] = (1930 ... Int(CustomDateFormatter.getYear(from: .now))!)
       .map { .init(description: $0.description + "년", id: $0) }
       .reversed()
+    return [SelectYearBottomSheetItem.notSelectedItem] + defaultItems
+  }
+}
+
+extension SelectYearBottomSheetItem {
+  static var notSelectedItem: Self {
+    let notSelectedID = Int(CustomDateFormatter.getYear(from: .now))! + 1
+    return SelectYearBottomSheetItem(description: "미선택", id: notSelectedID)
   }
 }
 

--- a/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditional.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditional.swift
@@ -74,8 +74,9 @@ struct OnboardingAdditional {
       case .view(.tappedBirthButton):
         state.bottomSheet =
           .init(
-            items: BottomSheetYearItem.makeDefaultItems(),
-            selectedItem: state.helper.$selectedBirth
+            items: .default,
+            selectedItem: state.helper.$selectedBirth,
+            deselectItem: .deselectItem
           )
         return .none
 

--- a/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditionalProperty.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditionalProperty.swift
@@ -87,17 +87,32 @@ public struct BottomSheetYearItem: SSSelectBottomSheetPropertyItemable {
   public var id: Int
 }
 
-extension BottomSheetYearItem {
-  static func makeDefaultItems() -> [Self] {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy"
-    let nowYear = dateFormatter.string(from: Date.now)
-    guard let nowYearToInt = Int(nowYear) else {
-      return []
-    }
-    let items: [Self] = (1950 ... nowYearToInt).map { val in
-      return .init(description: val.description + "년", id: val)
-    }
-    return items.reversed()
+extension [BottomSheetYearItem] {
+  static var `default`: Self {
+    BottomSheetYearItem.default
   }
+}
+
+extension BottomSheetYearItem {
+  static var `default`: [Self] {
+    let defaultItems: [Self] = (1930 ... Int(getYear(from: .now))!)
+      .map { .init(description: $0.description + "년", id: $0) }
+      .reversed()
+    return [.deselectItem] + defaultItems
+  }
+
+  static var deselectItem: Self {
+    let notSelectedID = Int(getYear(from: .now))! + 1
+    return .init(description: "미선택", id: notSelectedID)
+  }
+
+  private static func getYear(from date: Date) -> String {
+    dateFormatter.string(from: date)
+  }
+
+  private static let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy"
+    return formatter
+  }()
 }

--- a/Projects/Share/SSBottomSelectSheet/Sources/SSSelectableBottomSheetReducer.swift
+++ b/Projects/Share/SSBottomSelectSheet/Sources/SSSelectableBottomSheetReducer.swift
@@ -18,9 +18,11 @@ public struct SSSelectableBottomSheetReducer<Item: SSSelectBottomSheetPropertyIt
 
     var items: [Item]
     @Shared var selectedItem: Item?
-    public init(items: [Item], selectedItem: Shared<Item?>) {
+    var deselectItem: Item? = nil
+    public init(items: [Item], selectedItem: Shared<Item?>, deselectItem: Item? = nil) {
       self.items = items
       _selectedItem = selectedItem
+      self.deselectItem = deselectItem
     }
   }
 
@@ -40,7 +42,7 @@ public struct SSSelectableBottomSheetReducer<Item: SSSelectBottomSheetPropertyIt
         return .none
       case let .tapped(item: item):
         let isChanged = item != state.selectedItem
-        state.selectedItem = item
+        state.selectedItem = state.deselectItem == item ? nil : item
         return .run { send in
           if isChanged {
             await send(.changedItem(item))

--- a/Projects/Share/SSBottomSelectSheet/Sources/SSSelectableBottomSheetView.swift
+++ b/Projects/Share/SSBottomSelectSheet/Sources/SSSelectableBottomSheetView.swift
@@ -38,20 +38,22 @@ public struct SSSelectableBottomSheetView<Item: SSSelectBottomSheetPropertyItema
   private func makeContentView() -> some View {
     ScrollViewReader { value in
       ScrollView(showsIndicators: false) {
-        ZStack {
+        ZStack(alignment: .center) {
           Spacer().containerRelativeFrame([.horizontal, .vertical])
 
           VStack(alignment: .center, spacing: 0) {
             makeCellContentView()
+              .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.09) {
+                  value.scrollTo(store.selectedItem?.id, anchor: .center)
+                }
+              }
           }
           .scrollTargetLayout()
         }
       }
-      .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
       .scrollTargetBehavior(.viewAligned)
-      .onAppear {
-        value.scrollTo(store.selectedItem?.id, anchor: .center)
-      }
+      .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
     }
   }
 


### PR DESCRIPTION
## 작업 내용

- [x] ScrollView 버그 수정(DispatchQueue.main.asyncafter활용)
- [x] bottomSheet DeselectItem 항목 추가를 통한 미선택 구현
- [x] select item 로직 수정

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)


|View|View|
|:-:|:-:|
|![IMG_9948](https://github.com/user-attachments/assets/b4486843-b0d2-4391-9950-4b8bfb83ad01)|![IMG_9949](https://github.com/user-attachments/assets/3dd28c6f-46cc-4737-9537-f4f478e7b5bb)|


<br/><br/><br/>


## 고민점 및 해결 방법

scrollView가 간헐적으로 시작 위치로 움직이지 않는 버그가 존재하였음. 이를 수정하기 위해서 Dispatchqueue main async를 활용하여 뷰 로딩이 끝난 이후에 scroll Position을 움직이게 코드를 디자인 하였음. 






<br/><br/><br/>
## 논의 해봤으면 좋으점(Optional)




<br/><br/><br/>
close: #354
close: #
