### PR TITLE
[Refactor] iOS Error 처리 Message FireBase -> Discord WebHook으로 전환

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -20,6 +20,7 @@ let project = Project.makeModule(
       .feature(.onboarding),
       .feature(.sSLaunchScreen),
       .feature(.sSLogin),
+      .feature(.sSErrorHandler),
     ],
     testDependencies: [],
     infoPlist: [
@@ -27,7 +28,7 @@ let project = Project.makeModule(
       "UILaunchStoryboardName": "LaunchScreen",
       "BGTaskSchedulerPermittedIdentifiers": "com.oksusu.susu.app",
       "CFBundleShortVersionString": "1.0.5",
-      "CFBundleVersion": "2024092430",
+      "CFBundleVersion": "2024092531",
       "UIUserInterfaceStyle": "Light",
       "ITSAppUsesNonExemptEncryption": "No",
       "AppstoreAPPID": "6503701515",

--- a/Projects/App/Sources/App/AppDelegate.swift
+++ b/Projects/App/Sources/App/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import Designsystem
 import FirebaseCore
+import SSErrorHandler
 import SwiftUI
 import UIKit
 
@@ -18,6 +19,7 @@ class MyAppDelegate: NSObject, UIApplicationDelegate {
   ) -> Bool {
     Font.registerFont()
     registerFirebase()
+    DiscordErrorHandler.shared.registerDiscordLogSystem()
     return true
   }
 

--- a/Projects/App/Sources/Views/ContentView.swift
+++ b/Projects/App/Sources/Views/ContentView.swift
@@ -136,10 +136,6 @@ public struct ContentView: View {
           didTapCompletionButton: { _ in }
         )
       )
-      .onReceive(NotificationCenter.default.publisher(for: SSNotificationName.logError)) { errorObjectOutput in
-        let errorObject = errorObjectOutput.object as? [String: Any] ?? [:]
-        ssErrorLogEvent(parameters: errorObject)
-      }
       .onReceive(NotificationCenter.default.publisher(for: SSNotificationName.showDefaultNetworkErrorAlert)) { _ in
         isShowDefaultNetworkErrorAlert = true
       }

--- a/Projects/Core/FeatureAction/Project.swift
+++ b/Projects/Core/FeatureAction/Project.swift
@@ -11,6 +11,7 @@ let project = Project.makeModule(
       .core(.sSNotification),
       .thirdParty(.ComposableArchitecture),
       .thirdParty(.SwiftAsyncMutex),
+      .core(.sSPersistancy),
     ]
   )
 )

--- a/Projects/Core/FeatureAction/Sources/ssRun.swift
+++ b/Projects/Core/FeatureAction/Sources/ssRun.swift
@@ -25,10 +25,13 @@ public extension Effect {
       NotificationCenter.default.post(name: SSNotificationName.showDefaultNetworkErrorAlert, object: nil)
     }
     return .run(priority: priority, operation: operation) { error, send in
+
+      var errorDescription = String(customDumping: error)
+
       // LogError
       let errorMessage =
         """
-        ErrorMessage: \(String(customDumping: error))
+        \(errorDescription)
         FileID: \(fileID.description)
         filePath: \(filePath.description)
         line: \(line.description)
@@ -57,5 +60,20 @@ public extension Effect {
         column: column
       )
     }
+  }
+}
+
+extension Array {
+  subscript(safe index: Int) -> Element? {
+    indices.contains(index) ? self[index] : nil
+  }
+
+  subscript(safeBounds bounds: Range<Int>) -> ArraySlice<Element>? {
+    let safeLowerBound = Swift.max(bounds.lowerBound, startIndex)
+    let safeUpperBound = Swift.min(bounds.upperBound, endIndex)
+    guard safeLowerBound < safeUpperBound else {
+      return nil
+    }
+    return self[safeLowerBound ..< safeUpperBound]
   }
 }

--- a/Projects/Core/FeatureAction/Sources/ssRun.swift
+++ b/Projects/Core/FeatureAction/Sources/ssRun.swift
@@ -9,6 +9,7 @@
 import ComposableArchitecture
 import Foundation
 import SSNotification
+import SSPersistancy
 
 public extension Effect {
   static func ssRun(
@@ -37,6 +38,7 @@ public extension Effect {
         line: \(line.description)
         column: \(column.description)
         date: \(Date.now.description)
+        userID: \(SSTokenManager.shared.getUserID()?.description ?? "Unknwon")
         """
       NotificationCenter.default.post(name: SSNotificationName.logError, object: errorMessage)
 

--- a/Projects/Core/FeatureAction/Sources/ssRun.swift
+++ b/Projects/Core/FeatureAction/Sources/ssRun.swift
@@ -26,14 +26,15 @@ public extension Effect {
     }
     return .run(priority: priority, operation: operation) { error, send in
       // LogError
-      let errorObject: [String: Any] = [
-        "ErrorMessage": String(customDumping: error),
-        "FileID": fileID.description,
-        "filePath": filePath.description,
-        "line": line.description,
-        "column": column.description,
-      ]
-      NotificationCenter.default.post(name: SSNotificationName.logError, object: errorObject)
+      let errorMessage =
+        """
+        ErrorMessage: \(String(customDumping: error))
+        FileID: \(fileID.description)
+        filePath: \(filePath.description)
+        line: \(line.description)
+        column: \(column.description)
+        """
+      NotificationCenter.default.post(name: SSNotificationName.logError, object: errorMessage)
 
       // Select Error Handler
       let currentErrorHandler = handler == nil ? defaultErrorHandler : handler!

--- a/Projects/Core/FeatureAction/Sources/ssRun.swift
+++ b/Projects/Core/FeatureAction/Sources/ssRun.swift
@@ -33,6 +33,7 @@ public extension Effect {
         filePath: \(filePath.description)
         line: \(line.description)
         column: \(column.description)
+        date: \(Date.now.description)
         """
       NotificationCenter.default.post(name: SSNotificationName.logError, object: errorMessage)
 

--- a/Projects/Core/SSInterceptor/Sources/HealthCheckTargetType.swift
+++ b/Projects/Core/SSInterceptor/Sources/HealthCheckTargetType.swift
@@ -15,7 +15,7 @@ import SSNetwork
 struct HealthCheck: SSNetworkTargetType {
   init() {}
   var additionalHeader: [String: String]? { nil }
-  var path: String { "healthh" }
+  var path: String { "health" }
   var method: Moya.Method { .get }
   var task: Moya.Task { .requestPlain }
 }

--- a/Projects/Core/SSInterceptor/Sources/RefreshTokenTargetType.swift
+++ b/Projects/Core/SSInterceptor/Sources/RefreshTokenTargetType.swift
@@ -34,15 +34,27 @@ public struct RefreshTokenTargetType: SSNetworkTargetType {
 // MARK: - ValidTokenTargetType
 
 public struct ValidTokenTargetType: SSNetworkTargetType {
-  public var additionalHeader: [String: String]? = nil
+  public let additionalHeader: [String: String]? = nil
 
-  public var path: String = "envelopes"
+  public let path: String = "envelopes"
 
-  public var method: Moya.Method = .get
+  public let method: Moya.Method = .get
 
-  public var task: Moya.Task {
-    .requestPlain
-  }
+  public let task: Moya.Task = .requestPlain
+  init() {}
+}
+
+// MARK: - MyInfoTargetType
+
+public struct MyInfoTargetType: SSNetworkTargetType {
+  public let additionalHeader: [String: String]? = nil
+
+  public let path: String = "users/my-info"
+
+  public let method: Moya.Method = .get
+
+  public let task: Moya.Task = .requestPlain
+  init() {}
 }
 
 // MARK: - RefreshResponseDTO

--- a/Projects/Core/SSInterceptor/Sources/SSTokenInterceptor.swift
+++ b/Projects/Core/SSInterceptor/Sources/SSTokenInterceptor.swift
@@ -144,4 +144,17 @@ public extension SSTokenInterceptor {
       os_log("\(error)")
     }
   }
+
+  func setUserNameByAccessToken() async throws {
+    let provider = MoyaProvider<MyInfoTargetType>(session: .init(interceptor: Self.shared))
+    let response: UserInfoResponse = try await provider.request(.init())
+    let userID = response.id
+    try SSTokenManager.shared.saveUserID(userID)
+  }
+}
+
+// MARK: - UserInfoResponse
+
+private struct UserInfoResponse: Decodable {
+  let id: Int64
 }

--- a/Projects/Core/SSPersistancy/Sources/SSTokenManager.swift
+++ b/Projects/Core/SSPersistancy/Sources/SSTokenManager.swift
@@ -81,6 +81,21 @@ public final class SSTokenManager {
     SSKeychain.shared.delete(key: String(describing: SSToken.self))
   }
 
+  private let userIDKey: String = "UserID"
+  public func saveUserID(_ val: Int64) throws {
+    let dataOfUserID = try encoder.encode(val)
+    try SSKeychain.shared.save(key: userIDKey, value: dataOfUserID)
+  }
+
+  public func getUserID() -> Int64? {
+    guard let userIDData = SSKeychain.shared.load(key: userIDKey),
+          let userID = try? decoder.decode(Int64.self, from: userIDData)
+    else {
+      return nil
+    }
+    return userID
+  }
+
   private init() {}
 
   private enum Constants: String {

--- a/Projects/Core/SSPersistancy/Sources/SSTokenManager.swift
+++ b/Projects/Core/SSPersistancy/Sources/SSTokenManager.swift
@@ -81,19 +81,28 @@ public final class SSTokenManager {
     SSKeychain.shared.delete(key: String(describing: SSToken.self))
   }
 
-  private let userIDKey: String = "UserID"
+  private let userIDKey: String = "SUSU_USER_ID"
   public func saveUserID(_ val: Int64) throws {
     let dataOfUserID = try encoder.encode(val)
-    try SSKeychain.shared.save(key: userIDKey, value: dataOfUserID)
+    SSKeychain.shared.save(key: userIDKey, data: dataOfUserID)
   }
 
   public func getUserID() -> Int64? {
-    guard let userIDData = SSKeychain.shared.load(key: userIDKey),
-          let userID = try? decoder.decode(Int64.self, from: userIDData)
+    guard let userIDData = SSKeychain.shared.load(key: userIDKey)
     else {
       return nil
     }
+    let userID = try? decoder.decode(Int64.self, from: userIDData)
     return userID
+  }
+
+  public func removeUserID() {
+    SSKeychain.shared.delete(key: userIDKey)
+  }
+
+  public func removeCurrentUserInformation() {
+    removeUserID()
+    removeToken()
   }
 
   private init() {}

--- a/Projects/Feature/MyPage/Sources/MyPageMain/MyPageMain.swift
+++ b/Projects/Feature/MyPage/Sources/MyPageMain/MyPageMain.swift
@@ -119,7 +119,7 @@ struct MyPageMain {
 
     case .pushOnboarding:
       NotificationCenter.default.post(name: SSNotificationName.logout, object: nil)
-      SSTokenManager.shared.removeToken()
+      SSTokenManager.shared.removeCurrentUserInformation()
       return .none
 
     case let .updateIsShowUpdateSUSUVersion(version):
@@ -176,6 +176,7 @@ struct MyPageMain {
           }
         } catch {
           os_log(.fault, "\(error.localizedDescription)")
+          throw error
         }
         await send(.inner(.pushOnboarding))
       }

--- a/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditionalPercistence.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingAdditional/OnboardingAdditionalPercistence.swift
@@ -11,17 +11,17 @@ import OSLog
 import SSPersistancy
 
 enum OnboardingAdditionalPersistence {
-  static func saveToken(_ val: SignUpResponseDTO) {
+  static func saveToken(_ val: SignUpResponseDTO) throws {
     let token = SSToken(
       accessToken: val.accessToken,
       accessTokenExp: val.accessTokenExp,
       refreshToken: val.refreshToken,
       refreshTokenExp: val.refreshTokenExp
     )
-    do {
-      try SSTokenManager.shared.saveToken(token)
-    } catch {
-      os_log("토큰 저장에 실패하였습니다.")
-    }
+    try SSTokenManager.shared.saveToken(token)
+  }
+
+  static func saveUserID(_ val: Int64) async throws {
+    try SSTokenManager.shared.saveUserID(val)
   }
 }

--- a/Projects/Feature/SSErrorHandler/Project.swift
+++ b/Projects/Feature/SSErrorHandler/Project.swift
@@ -1,0 +1,16 @@
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+  name: "SSErrorHandler",
+  targets: .feature(
+    .sSErrorHandler,
+    testingOptions: [],
+    dependencies: [
+      .core(.sSNotification),
+    ],
+    testDependencies: [],
+    infoPlist: ["DISCORD_WEB_HOOK_URL": "$(DISCORD_WEB_HOOK_URL"]
+  )
+)

--- a/Projects/Feature/SSErrorHandler/Resources/KeepResources.swift
+++ b/Projects/Feature/SSErrorHandler/Resources/KeepResources.swift
@@ -1,0 +1,1 @@
+// Content of KeepResources.swift

--- a/Projects/Feature/SSErrorHandler/Sources/DiscordErrorHandler.swift
+++ b/Projects/Feature/SSErrorHandler/Sources/DiscordErrorHandler.swift
@@ -1,0 +1,67 @@
+//
+//  DiscordErrorHandler.swift
+//  SSErrorHandler
+//
+//  Created by MaraMincho on 9/25/24.
+//  Copyright © 2024 com.oksusu. All rights reserved.
+//
+
+import Combine
+import Foundation
+import OSLog
+import SSNotification
+
+public final class DiscordErrorHandler {
+  public static let shared = DiscordErrorHandler()
+  var subscription: AnyCancellable?
+  private init() {}
+
+  public func registerDiscordLogSystem() {
+    subscription = NotificationCenter.default.publisher(for: SSNotificationName.logError)
+      .sink { @Sendable errorObjectOutput in
+        let errorObject = errorObjectOutput.object as? String
+        Self.sendErrorToDiscord(errorMessage: errorObject)
+      }
+  }
+
+  public func removeDiscordLogSystem() {
+    subscription = nil
+  }
+
+  @Sendable private static func sendErrorToDiscord(errorMessage message: String?) {
+    guard let message else {
+      return
+    }
+    guard
+      let webhookURLString = Bundle(for: self).infoDictionary?["DISCORD_WEB_HOOK_URL"] as? String,
+      let webhookURL = URL(string: webhookURLString)
+    else {
+      os_log("Discord Web Hook URL이 잘못되었습니다. 확인해주세요")
+      return
+    }
+
+    let payload: [String: Any] = ["content": message]
+    // JSON 데이터로 변환
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+      os_log("Json 직렬화가 불가능 합니다. 확인해주세요")
+      return
+    }
+
+    // URL 요청 설정
+    var request = URLRequest(url: webhookURL)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = jsonData
+
+    // URLSession을 통해 요청 전송
+    let task = URLSession.shared.dataTask(with: request) { _, _, error in
+      if let error {
+        os_log("Error sending message to Discord: \(error)")
+      } else {
+        os_log("Message sent successfully to Discord")
+      }
+    }
+
+    task.resume()
+  }
+}

--- a/Projects/Feature/SSErrorHandler/Sources/KeepSources.swift
+++ b/Projects/Feature/SSErrorHandler/Sources/KeepSources.swift
@@ -1,1 +1,0 @@
-// Content of KeepSources.swift

--- a/Projects/Feature/SSErrorHandler/Sources/KeepSources.swift
+++ b/Projects/Feature/SSErrorHandler/Sources/KeepSources.swift
@@ -1,0 +1,1 @@
+// Content of KeepSources.swift

--- a/Projects/Feature/SSErrorHandler/Tests/SSErrorHandlerTest.swift
+++ b/Projects/Feature/SSErrorHandler/Tests/SSErrorHandlerTest.swift
@@ -1,0 +1,6 @@
+
+import XCTest
+
+final class SSErrorHandlerTests: XCTestCase {
+  override func setUp() {}
+}

--- a/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenHelper.swift
+++ b/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenHelper.swift
@@ -34,7 +34,7 @@ struct LaunchScreenTokenNetwork {
       os_log("토큰 갱신에 성공하였습니다.")
 
       await prevUserNewFeature105()
-      
+
       return .prevUser
     } catch {
       os_log("\(error.localizedDescription)")
@@ -44,7 +44,7 @@ struct LaunchScreenTokenNetwork {
 
   /// 1.0.5 버전에 ACCESSTOKEN에 관한 로직입니다.
   private static func prevUserNewFeature105() async {
-    /// 만약 USERID가 없을 경우에 로직을 실행합니다.
+    // 만약 USERID가 없을 경우에 로직을 실행합니다.
     if SSTokenManager.shared.getUserID() == nil {
       try? await SSTokenInterceptor.shared.setUserNameByAccessToken()
       os_log("유저 아이디 저장에 성공하였습니다.")

--- a/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenHelper.swift
+++ b/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenHelper.swift
@@ -17,7 +17,7 @@ import SSPersistancy
 
 struct LaunchScreenTokenNetwork {
   var checkTokenValid: () async -> EndedLaunchScreenStatus
-  static func _checkTokenValid() async -> EndedLaunchScreenStatus {
+  private static func _checkTokenValid() async -> EndedLaunchScreenStatus {
     // 기존 유저인지 검사합니다.
     if !SSTokenManager.shared.isToken() {
       return .newUser
@@ -32,10 +32,22 @@ struct LaunchScreenTokenNetwork {
       try await SSTokenInterceptor.shared.isValidToken()
       try await SSTokenInterceptor.shared.refreshTokenWithNetwork()
       os_log("토큰 갱신에 성공하였습니다.")
+
+      await prevUserNewFeature105()
+      
       return .prevUser
     } catch {
       os_log("\(error.localizedDescription)")
       return newUserRoutine()
+    }
+  }
+
+  /// 1.0.5 버전에 ACCESSTOKEN에 관한 로직입니다.
+  private static func prevUserNewFeature105() async {
+    /// 만약 USERID가 없을 경우에 로직을 실행합니다.
+    if SSTokenManager.shared.getUserID() == nil {
+      try? await SSTokenInterceptor.shared.setUserNameByAccessToken()
+      os_log("유저 아이디 저장에 성공하였습니다.")
     }
   }
 

--- a/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenMain.swift
+++ b/Projects/Feature/SSLaunchScreen/Sources/LaunchScreenMain/LaunchScreenMain.swift
@@ -20,7 +20,6 @@ struct LaunchScreenMain {
 
   enum Action: Equatable {
     case onAppear(Bool)
-    case runTask
     case mandatoryUpdateAlert(Bool)
   }
 
@@ -36,10 +35,8 @@ struct LaunchScreenMain {
       case let .onAppear(isAppear):
         state.isOnAppear = isAppear
         routingPublisher.send(.launchTaskWillRun)
-        return .send(.runTask)
-
-      case .runTask:
         let appVersion = InfoPlistConstants.appVersion
+
         return .run { send in
           if await launchScreenNetwork.getIsMandatoryUpdate(appVersion) {
             await send(.mandatoryUpdateAlert(true))

--- a/Tuist/ProjectDescriptionHelpers/Dependency+FeatureTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+FeatureTarget.swift
@@ -26,6 +26,7 @@ public enum Feature: String {
   case sSEnvelope
   case sSEditSingleSelectButton
   case sSLogin
+  case sSErrorHandler
   public var targetName: String {
     return rawValue.prefix(1).capitalized + rawValue.dropFirst()
   }


### PR DESCRIPTION
## 작업 내용

- [x] 기존 FireBase to Discord로 에러 처리 로직 변경 
- [x] Discord를 통한 에러 처리 로직 추가 
- [x] UserID 저장하는 로직 추가 


<br/><br/><br/>
close: #590
close: #592
