### PR TITLE
[Refactor / Feature]  Vote Content Headers 콘텐트 스크롤뷰 조정, runWithStartFinishAction 코드 변경 

### DIFF
--- a/Projects/Core/FeatureAction/Sources/ComposableArchitecture.Effect+.swift
+++ b/Projects/Core/FeatureAction/Sources/ComposableArchitecture.Effect+.swift
@@ -22,6 +22,6 @@ public extension ComposableArchitecture.Effect {
       try await operation(send)
       try await endOperation(send)
     }
-    return .run(priority: priority, operation: currentOperation, catch: handler)
+    return .ssRun(priority: priority, operation: currentOperation, catch: handler)
   }
 }

--- a/Projects/Feature/Vote/Sources/VoteMain/VoteMainView.swift
+++ b/Projects/Feature/Vote/Sources/VoteMain/VoteMainView.swift
@@ -214,23 +214,28 @@ struct VoteMainView: View {
   /// Sticky Header
   @ViewBuilder
   private func makeHeaderSection() -> some View {
-    HStack(alignment: .top, spacing: 4) {
-      ForEach(store.voteMainProperty.voteSectionItems) { item in
-        let isSelected = store.voteMainProperty.selectedVoteSectionItem == item
-        SSButton(
-          .init(
-            size: .xsh28,
-            status: isSelected ? .active : .inactive,
-            style: .filled,
-            color: .black,
-            buttonText: item.title
-          )) {
-            store.send(.view(.tappedSectionItem(item)))
-          }
+    ScrollView(.horizontal) {
+      HStack(alignment: .top, spacing: 4) {
+        ForEach(store.voteMainProperty.voteSectionItems) { item in
+          let isSelected = store.voteMainProperty.selectedVoteSectionItem == item
+          SSButton(
+            .init(
+              size: .xsh28,
+              status: isSelected ? .active : .inactive,
+              style: .filled,
+              color: .black,
+              buttonText: item.title
+            )) {
+              store.send(.view(.tappedSectionItem(item)))
+            }
+        }
       }
     }
+    .scrollIndicators(.hidden)
+    .scrollBounceBehavior(.basedOnSize)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(16)
+    .padding(.vertical, 16)
+    .safeAreaPadding(.horizontal, 16)
     .background(SSColor.gray10)
   }
 


### PR DESCRIPTION
## 작업 내용

- [x] [Refactor] runWithStartFinishAction run -> ssRun으로 코드 변경
- [x] [Feature] Vote Content Headers 콘텐트 스크롤뷰 조정

## 화면 (뷰를 생성했을 경우 스크린샷을 부해주세요)

![RPReplay_Final1727854167](https://github.com/user-attachments/assets/9bbd51e8-8030-4b22-97e1-06acab11cbd5)



<br/><br/><br/>
close: #608
close: #609
